### PR TITLE
Fix color shifts, improve fading

### DIFF
--- a/inc/vdp_pal.h
+++ b/inc/vdp_pal.h
@@ -13,9 +13,9 @@
 #define _VDP_PAL_H_
 
 
-#define VDPPALETTE_REDSFT           9
+#define VDPPALETTE_REDSFT           1
 #define VDPPALETTE_GREENSFT         5
-#define VDPPALETTE_BLUESFT          1
+#define VDPPALETTE_BLUESFT          9
 
 #define VDPPALETTE_REDMASK          0x000E
 #define VDPPALETTE_GREENMASK        0x00E0

--- a/src/vdp_pal.c
+++ b/src/vdp_pal.c
@@ -225,6 +225,9 @@ void VDP_setPaletteColor(u16 index, u16 value)
     *pw = value;
 }
 
+static u16 palround(u16 in) {
+    return (in + 127) >> PALETTEFADE_FRACBITS;
+}
 
 static void setFadePalette(u16 waitVSync)
 {
@@ -261,9 +264,9 @@ static void setFadePalette(u16 waitVSync)
     {
         u16 col;
 
-        col = ((*palR++ >> PALETTEFADE_FRACBITS) << VDPPALETTE_REDSFT) & VDPPALETTE_REDMASK;
-        col |= ((*palG++ >> PALETTEFADE_FRACBITS) << VDPPALETTE_GREENSFT) & VDPPALETTE_GREENMASK;
-        col |= ((*palB++ >> PALETTEFADE_FRACBITS) << VDPPALETTE_BLUESFT) & VDPPALETTE_BLUEMASK;
+        col = (palround(*palR++) << VDPPALETTE_REDSFT) & VDPPALETTE_REDMASK;
+        col |= (palround(*palG++) << VDPPALETTE_GREENSFT) & VDPPALETTE_GREENMASK;
+        col |= (palround(*palB++) << VDPPALETTE_BLUESFT) & VDPPALETTE_BLUEMASK;
 
         *pw = col;
     }


### PR DESCRIPTION
Without rounding, the fade had a lot of errors when compared to a float
implementation. Rounding like this removed 82% of the errors.

Left is old and right is new.

![Imgur](http://i.imgur.com/mU756Yb.gifv)