### PR TITLE
Include vram.h for building the library.  Thanks lifning

### DIFF
--- a/src/vram.c
+++ b/src/vram.c
@@ -9,7 +9,7 @@
 #include "tools.h"
 #include "sys.h"
 #include "kdebug.h"
-
+#include "vram.h"
 
 #define USED_SFT    15
 #define USED_MASK   (1 << USED_SFT)
@@ -206,7 +206,7 @@ s16 VRAM_alloc(VRAMRegion *region, u16 size)
     if (size > *free)
     {
         // pack free block
-        p = pack(region, adjsize);
+        p = pack(region, size);
 
         // no enough memory
         if (p == NULL)


### PR DESCRIPTION
Error during building, due to vram.c not including vram.h:

/opt/toolchains/gen/m68k-elf/bin/m68k-elf-gcc  -Dnologo_  -m68000 -Wall -O1 -c -fomit-frame-pointer -Iinc -Ires  -c src/vram.c -o src/vram.o
In file included from src/vram.c:7:0:
inc/memory.h:199:6: warning: conflicting types for built-in function ‘memset’ [enabled by default]
 void memset(void *to, u8 value, u16 len);
      ^
inc/memory.h:242:6: warning: conflicting types for built-in function ‘memcpy’ [enabled by default]
 void memcpy(void *to, const void *from, u16 len);
      ^
src/vram.c:161:18: error: unknown type name ‘VRAMRegion’
 static u16* pack(VRAMRegion *region, u16 nsize);
                  ^
src/vram.c:164:24: error: unknown type name ‘VRAMRegion’
 void VRAM_createRegion(VRAMRegion *region, u16 startIndex, u16 size)
                        ^
src/vram.c:177:25: error: unknown type name ‘VRAMRegion’
 void VRAM_releaseRegion(VRAMRegion *region)
                         ^
src/vram.c:184:23: error: unknown type name ‘VRAMRegion’
 void VRAM_clearRegion(VRAMRegion *region)
                       ^
src/vram.c:197:16: error: unknown type name ‘VRAMRegion’
 s16 VRAM_alloc(VRAMRegion *region, u16 size)
                ^
src/vram.c:254:16: error: unknown type name ‘VRAMRegion’
 void VRAM_free(VRAMRegion *region, u16 index)
                ^
src/vram.c:263:18: error: unknown type name ‘VRAMRegion’
 u16 VRAM_getFree(VRAMRegion *region)
                  ^
src/vram.c:292:18: error: unknown type name ‘VRAMRegion’
 static u16* pack(VRAMRegion *region, u16 nsize)
                  ^
make: *** [src/vram.o] Error 1
