### PR TITLE
string.h: Enable printf warnings (supported since gcc 2.3)

### DIFF
--- a/inc/string.h
+++ b/inc/string.h
@@ -249,7 +249,7 @@ void fix16ToStr(fix16 value, char *str, s16 numdec);
  *  formatted and inserted in the resulting string replacing their respective specifiers
  *
  */
-u16 sprintf(char *buffer,const char *fmt, ...);
+u16 sprintf(char *buffer,const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
 
 
 #endif // _STRING_H_


### PR DESCRIPTION
This lets gcc check format strings, and warn about things like

sprintf(buf, "%u");

etc.