### PR TITLE
wavtoraw: Add detection for complex WAV files

### DIFF
--- a/tools/wavtoraw/src/wavtoraw.c
+++ b/tools/wavtoraw/src/wavtoraw.c
@@ -72,6 +72,11 @@ int main(int argc, char *argv[ ])
         saferead( infile, "%1c", &j);
 
     saferead( infile, "%4c", ckID );
+    if (ckID[0] != 'd') {
+        printf("This is not a simple WAV file, maybe it has a LIST chunk. "
+        	"Try to save in a different program, etc.\n");
+        exit(2);
+    }
     saferead( infile, "%4c", &nChunkSize );
 
     #undef saferead


### PR DESCRIPTION
Adds the warning requested in #116. We shouldn't close that issue until wavtoraw can process such files.