### PR TITLE
Improve assembly using macros and preprocessor

### DIFF
--- a/makefile.gen
+++ b/makefile.gen
@@ -117,7 +117,7 @@ out/symbol.txt: out/rom.out
 	$(NM) --plugin=liblto_plugin-0.dll -n out/rom.out > out/symbol.txt
 
 out/rom.out: out/sega.o out/cmd_ $(LIBMD)
-	$(CC) -B$(BIN) -n -T $(GDK)/md.ld -nostdlib out/sega.o @out/cmd_ $(LIBMD) $(LIB)/libgcc.a -o out/rom.out
+	$(CC) -B$(BIN) -n -T $(GDK)/md.ld -nostdlib out/sega.o @out/cmd_ $(LIBMD) $(LIB)/libgcc.a -o out/rom.out -Wl,--gc-sections
 	$(RM) out/cmd_
 
 out/cmd_: $(OBJS)

--- a/makelib.gen
+++ b/makelib.gen
@@ -21,6 +21,7 @@ MKDIR= $(BIN)/mkdir
 
 SRC_LIB_C= $(wildcard $(SRC_LIB)/*.c)
 SRC_LIB_S= $(wildcard $(SRC_LIB)/*.s)
+SRC_LIB_PPS= $(wildcard $(SRC_LIB)/*.S)
 SRC_LIB_S80= $(wildcard $(SRC_LIB)/*.s80)
 
 RES_LIB_RES= $(wildcard $(RES_LIB)/*.res)
@@ -28,6 +29,7 @@ RES_LIB_RES= $(wildcard $(RES_LIB)/*.res)
 OBJ_LIB= $(RES_LIB_RES:.res=.o)
 OBJ_LIB+= $(SRC_LIB_S80:.s80=.o)
 OBJ_LIB+= $(SRC_LIB_S:.s=.o)
+OBJ_LIB+= $(SRC_LIB_PPS:.S=.o)
 OBJ_LIB+= $(SRC_LIB_C:.c=.o)
 
 LST_LIB= $(SRC_LIB_C:.c=.lst)
@@ -105,6 +107,9 @@ cmd_ : $(OBJ_LIB)
 	$(CC) $(FLAGS_LIB) -c $< -o $@
 
 %.o: %.s
+	$(CC) $(FLAGS_LIB) -c $< -o $@
+
+%.o: %.S
 	$(CC) $(FLAGS_LIB) -c $< -o $@
 
 %.s: %.res

--- a/src/bmp_a.S
+++ b/src/bmp_a.S
@@ -1,6 +1,7 @@
-    .globl  clearBitmapBuffer
-    .type   clearBitmapBuffer, @function
-clearBitmapBuffer:
+
+#include "sgdk_asm_macros.h"
+
+func clearBitmapBuffer
     move.l 4(%sp),%a0           | a0 = buffer
     lea 20480(%a0),%a0          | a0 = buffer end
 
@@ -46,9 +47,7 @@ clearBitmapBuffer:
     rts
 
 
-    .globl  copyBitmapBuffer
-    .type   copyBitmapBuffer, @function
-copyBitmapBuffer:
+func copyBitmapBuffer
     move.l 4(%sp),%a0           | a0 = src
     move.l 8(%sp),%a1           | a1 = dest
 
@@ -125,9 +124,7 @@ copyBitmapBuffer:
     rts
 
 
-    .globl  BMP_setPixelFastA
-    .type   BMP_setPixelFastA, @function
-BMP_setPixelFastA:
+func BMP_setPixelFastA
     moveq   #-1,%d1                         | d1 = 0xFFFFFFFF
     move.w  6(%sp),%d0                      | d0 = X
     move.w  10(%sp),%d1                     | d1 = Y
@@ -166,9 +163,7 @@ BMP_setPixelFastA:
     rts
 
 
-    .globl  BMP_setPixelA
-    .type   BMP_setPixelA, @function
-BMP_setPixelA:
+func BMP_setPixelA
     moveq   #-1,%d1                         | d1 = 0xFFFFFFFF
     move.w  6(%sp),%d0                      | d0.w = X
     move.w  10(%sp),%d1                     | d1.w = Y
@@ -182,9 +177,7 @@ BMP_setPixelA:
     rts
 
 
-    .globl  BMP_setPixelsFast_V2D
-    .type   BMP_setPixelsFast_V2D, @function
-BMP_setPixelsFast_V2D:
+func BMP_setPixelsFast_V2D
     move.l  4(%sp),%a0                      | a0 = crd
     move.b  11(%sp),%d1                     | d1 = col
     move.w  14(%sp),%d0                     | d0 = num
@@ -237,9 +230,7 @@ BMP_setPixelsFast_V2D:
     rts
 
 
-    .globl  BMP_setPixels_V2D
-    .type   BMP_setPixels_V2D, @function
-BMP_setPixels_V2D:
+func BMP_setPixels_V2D
     move.l  4(%sp),%a0                      | a0 = crd
     move.b  11(%sp),%d1                     | d1 = col
     move.w  14(%sp),%d0                     | d0 = num
@@ -306,9 +297,7 @@ BMP_setPixels_V2D:
     rts
 
 
-    .globl  BMP_setPixelsFast
-    .type   BMP_setPixelsFast, @function
-BMP_setPixelsFast:
+func BMP_setPixelsFast
     move.l  4(%sp),%a0                      | a0 = pixels
     move.w  10(%sp),%d0                     | d0 = num
     subq.w  #1,%d0
@@ -360,9 +349,7 @@ BMP_setPixelsFast:
     rts
 
 
-    .globl  BMP_setPixels
-    .type   BMP_setPixels, @function
-BMP_setPixels:
+func BMP_setPixels
     move.l  4(%sp),%a0                      | a0 = pixels
     move.w  10(%sp),%d0                     | d0 = num
     subq.w  #1,%d0
@@ -429,9 +416,7 @@ BMP_setPixels:
     rts
 
 
-    .globl    BMP_clipLine
-    .type    BMP_clipLine, @function
-BMP_clipLine:
+func BMP_clipLine
     movm.l %d2-%d7,-(%sp)
 
     move.l 28(%sp),%a0          | a0 = &line
@@ -585,9 +570,7 @@ BMP_clipLine:
     rts
 
 
-    .globl   BMP_drawLine
-    .type    BMP_drawLine, @function
-BMP_drawLine:
+func BMP_drawLine
     movem.l %d2-%d7/%a2-%a5,-(%sp)
 
     move.l  44(%sp),%a0     | a0 = &line
@@ -737,9 +720,7 @@ BMP_drawLine:
     rts
 
 
-    .globl   BMP_isPolygonCulled
-    .type    BMP_isPolygonCulled, @function
-BMP_isPolygonCulled:
+func BMP_isPolygonCulled
     movm.l %d2-%d5,-(%sp)
 
     move.l 20(%sp),%a1          | a1 = pts
@@ -2001,9 +1982,7 @@ fillEdgeFast:
     | a3 = rightEdge
     | a4 = free use
 
-    .globl    BMP_drawPolygon
-    .type    BMP_drawPolygon, @function
-BMP_drawPolygon:
+func BMP_drawPolygon
     movm.l %d2-%d7/%a2-%a6,-(%sp)
 
     move.l 48(%sp),%a0      | a0 = pt = &pts[0]

--- a/src/maths3D_a.S
+++ b/src/maths3D_a.S
@@ -1,8 +1,8 @@
     .extern    viewport
 
-    .globl	M3D_transform
-    .type	M3D_transform, @function
-M3D_transform:
+#include "sgdk_asm_macros.h"
+
+func M3D_transform
     movm.l %d2-%d5/%a2-%a5,-(%sp)
 
     move.l 36(%sp),%a2             	| a2 = &transform
@@ -70,9 +70,7 @@ M3D_transform:
     rts
 
 
-    .globl    M3D_project_f16
-    .type    M3D_project_f16, @function
-M3D_project_f16:
+func M3D_project_f16
     movem.l %d2-%d7/%a2-%a3,-(%sp)
 
     move.l 36(%sp),%a0                      | a0 = s = src
@@ -137,9 +135,7 @@ M3D_project_f16:
     rts
 
 
-    .globl    M3D_project_s16
-    .type    M3D_project_s16, @function
-M3D_project_s16:
+func M3D_project_s16
     movem.l %d2-%d7/%a2-%a3,-(%sp)
 
     move.l 36(%sp),%a0                      | a0 = s = src

--- a/src/sgdk_asm_macros.h
+++ b/src/sgdk_asm_macros.h
@@ -1,0 +1,9 @@
+
+.macro func _name, _align=2
+    .section .text.asm.\_name
+    .globl  \_name
+    .type   \_name, @function
+    .align \_align
+  \_name:
+.endm
+

--- a/src/tools_a.S
+++ b/src/tools_a.S
@@ -6,9 +6,9 @@
 # void qsort(void** src, u16 size, _comparatorCallback* cb);
 # ---------------------------------------------------------------
 
-    .global qsort
+#include "sgdk_asm_macros.h"
 
-qsort:
+func qsort
     movem.l %a2-%a6,-(%sp)
 
     move.l  24(%sp),%a2             | a2 = src
@@ -126,10 +126,7 @@ partition:
 #
 # -------------------------------------------------------------------------------------------------
 
-    .global aplib_unpack
-    .global aplib_decrunch
-
-aplib_unpack:
+func aplib_unpack
     movem.l 4(%a7),%a0-%a1
 
 aplib_decrunch:
@@ -259,11 +256,8 @@ aplib_decrunch:
 # lz4w_unpack_a: A0 = Source / A1 = Destination / Returns unpacked size
 # u16 lz4w_unpack(const u8 *src, u8 *dest);  /* c prototype */
 # ---------------------------------------------------------------------------
-    .align    2
-    .globl    lz4w_unpack
-    .globl    lz4w_unpack_a
 
-lz4w_unpack:
+func lz4w_unpack
     move.l  4(%sp),%a0              | a0 = src
     move.l  8(%sp),%a1              | a1 = dst
 


### PR DESCRIPTION
This change will create functions in their own .text section so that
the linker can garbage collect them (via --gc-sections). This reduces
ROM usage by a few KBs in case the functions are not used.

TODO: Do the same for the other .s files under /src/, for now just did
the big ones to save space