### PR TITLE
Hash is not a standard directive prefix in GNU as

### DIFF
--- a/src/bmp_a.s
+++ b/src/bmp_a.s
@@ -1,5 +1,5 @@
 
-#include "asm_mac.i"
+.include "asm_mac.i"
 
 func clearBitmapBuffer
     move.l 4(%sp),%a0           | a0 = buffer

--- a/src/dma_a.s
+++ b/src/dma_a.s
@@ -1,5 +1,5 @@
 
-#include "asm_mac.i"
+.include "asm_mac.i"
 
 func flushQueue
 	move.w 6(%sp),%d0

--- a/src/kdebug.s
+++ b/src/kdebug.s
@@ -14,7 +14,7 @@
 * others should be preserved and
 * return value -if there is- is placed in d0
 
-#include "asm_mac.i"
+.include "asm_mac.i"
 
 **************
 * Pause Gens *

--- a/src/maths3D_a.s
+++ b/src/maths3D_a.s
@@ -1,6 +1,6 @@
     .extern    viewport
 
-#include "asm_mac.i"
+.include "asm_mac.i"
 
 func M3D_transform
     movm.l %d2-%d5/%a2-%a5,-(%sp)

--- a/src/memory_a.s
+++ b/src/memory_a.s
@@ -1,5 +1,5 @@
 
-#include "asm_mac.i"
+.include "asm_mac.i"
 
 func memset_
     move.w  14(%sp),%d0         | d0 = len

--- a/src/sram_a.s
+++ b/src/sram_a.s
@@ -1,5 +1,5 @@
 
-#include "asm_mac.i"
+.include "asm_mac.i"
 
 | extern u16 SRAM_readWord(u32 offset);
 func SRAM_readWord

--- a/src/sys_a.s
+++ b/src/sys_a.s
@@ -1,5 +1,5 @@
 
-#include "asm_mac.i"
+.include "asm_mac.i"
 
 func SYS_assertReset
 

--- a/src/tools_a.s
+++ b/src/tools_a.s
@@ -6,7 +6,7 @@
 # void qsort(void** src, u16 size, _comparatorCallback* cb);
 # ---------------------------------------------------------------
 
-#include "asm_mac.i"
+.include "asm_mac.i"
 
 func qsort
     movem.l %a2-%a6,-(%sp)

--- a/src/vdp_tile_a.s
+++ b/src/vdp_tile_a.s
@@ -1,5 +1,5 @@
 
-#include "asm_mac.i"
+.include "asm_mac.i"
 
 func VDP_loadBMPTileData
     movm.l #0x3c00,-(%sp)


### PR DESCRIPTION
Using "#include" instead of ".include" breaks builds with standard GNU tools. Please see https://sourceware.org/binutils/docs/as/I.html#I