### PR TITLE
docker: initial support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# Ignore git repo
+/.git
+
+# Ignore non-building related directories
+/sample/
+/doc/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM i386/debian:buster-slim
+RUN echo 'APT::Install-Suggests "false";' >> /etc/apt/apt.conf.d/30install-suggests \
+    && echo 'APT::Install-Recommends "false";' >> /etc/apt/apt.conf.d/30install-suggests \
+    && apt-get update -y
+
+RUN apt-get install -y wine
+RUN apt-get install -y make
+
+# workdaround required for jdk
+RUN mkdir -p /usr/share/man/man1
+RUN apt-get install -y openjdk-11-jdk-headless
+
+ADD . /sgdk
+WORKDIR /sgdk
+ADD https://raw.githubusercontent.com/Franticware/SGDK_wine/main/generate_wine.sh bin/generate_wine.sh
+RUN cd bin && sh generate_wine.sh
+
+ENV GDK=/sgdk
+WORKDIR /src
+ENTRYPOINT [ "make", "-f", "/sgdk/makefile_wine.gen" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,11 @@ RUN apt-get install -y openjdk-11-jdk-headless
 
 ADD . /sgdk
 WORKDIR /sgdk
-ADD https://raw.githubusercontent.com/Franticware/SGDK_wine/main/generate_wine.sh bin/generate_wine.sh
+
+# Crudely get the script from github.
+# This isn't very secure, but at least we use the commit hash.
+# Ideally that repository should simply be merged into this one.
+ADD https://raw.githubusercontent.com/Franticware/SGDK_wine/c8a580a06f20fb45f43a18b65849e318b5f1341e/generate_wine.sh bin/generate_wine.sh
 RUN cd bin && sh generate_wine.sh
 
 ENV GDK=/sgdk

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,7 @@ To build the `sgdk` base image:
 And then to compile the local env, such as `samples` for example:
 
     cd sample/sprite
-    docker run -it -v $PWD:/src sgdk
+    docker run --rm -v $PWD:/src sgdk
 
 Note: `$PWD` will not work on Windows, there `%CD%` has to be used instead.
 

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,21 @@ But it seems to be outdated and is more complexe to setup than Wine based soluti
 MacOSX users also have access to SGDK with Gendev for MacOS from Sonic3D project:<br>
 https://github.com/SONIC3D/gendev-macos
 
+### Docker
+
+*A modern way to install it on any environement is to use Docker.*
+
+To build the `sgdk` base image:
+
+    docker build -t sgdk .
+
+And then to compile the local env, such as `samples` for example:
+
+    cd sample/sprite
+    docker run -it -v $PWD:/src sgdk
+
+Note: `$PWD` will not work on Windows, there `%CD%` has to be used instead.
+
  
 ### VISUAL STUDIO
 


### PR DESCRIPTION
This is using the nice wine layer from https://github.com/Franticware/SGDK_wine.
It enables a native usage, and is therefore much easier to sync with SGDK than the gendev project.

The bad part being that it uses the compiled binaries directly from the git repo.