### PR TITLE
Added JOY_writeJoypadX(u16 joy, u16 pos);

### DIFF
--- a/inc/joy.h
+++ b/inc/joy.h
@@ -326,6 +326,21 @@ s16  JOY_readJoypadX(u16 joy);
 
 /**
  *  \brief
+ *      Write joypad X axis.
+ *
+ *  \param joy
+ *      Joypad we query state.<br>
+ *      <b>JOY_1</b>    = joypad 1<br>
+ *      <b>JOY_2</b>    = joypad 2<br>
+ *      <b>...  </b>    = ...<br>
+ *      <b>JOY_8</b>    = joypad 8 (only possible with 2 teamplayers connected)<br>
+ *  \param pos
+ *      Desired X position for joypad.<br>
+ */
+s16  JOY_writeJoypadX(u16 joy, u16 pos);
+
+/**
+ *  \brief
  *      Get joypad Y axis.
  *
  *  \param joy
@@ -347,6 +362,21 @@ s16  JOY_readJoypadX(u16 joy);
  *<br>
  */
 s16  JOY_readJoypadY(u16 joy);
+
+/**
+ *  \brief
+ *      Write joypad Y axis.
+ *
+ *  \param joy
+ *      Joypad we query state.<br>
+ *      <b>JOY_1</b>    = joypad 1<br>
+ *      <b>JOY_2</b>    = joypad 2<br>
+ *      <b>...  </b>    = ...<br>
+ *      <b>JOY_8</b>    = joypad 8 (only possible with 2 teamplayers connected)<br>
+ *  \param pos
+ *      Desired Y position for joypad.<br>
+ */
+s16  JOY_writeJoypadY(u16 joy, u16 pos);
 
 /**
  *  \brief

--- a/src/joy.c
+++ b/src/joy.c
@@ -768,7 +768,7 @@ static u16 readMouse(u16 port)
             if (md[0] & 0x02)
                 my |= my ? 0xFF00 : 0xFFFF; /* y sign extend */
             joyAxisX[port] += (s16)mx;
-            joyAxisY[port] += (s16)my;
+            joyAxisY[port] -= (s16)my;
 
             if (md[1] & 8) val |= BUTTON_START;
             if (md[1] & 4) val |= BUTTON_MMB;

--- a/src/joy.c
+++ b/src/joy.c
@@ -511,6 +511,7 @@ u16 JOY_readJoypad(u16 joy)
     return 0;
 }
 
+
 s16 JOY_readJoypadX(u16 joy)
 {
     if (joy < JOY_NUM)
@@ -519,10 +520,26 @@ s16 JOY_readJoypadX(u16 joy)
     return 0;
 }
 
+s16 JOY_writeJoypadX(u16 joy, u16 pos)
+{
+    if (joy < JOY_NUM)
+        joyAxisX[joy]=pos;
+
+    return 0;
+}
+
 s16 JOY_readJoypadY(u16 joy)
 {
     if (joy < JOY_NUM)
         return joyAxisY[joy];
+
+    return 0;
+}
+
+s16 JOY_writeJoypadY(u16 joy, u16 pos)
+{
+    if (joy < JOY_NUM)
+        joyAxisY[joy]=pos;
 
     return 0;
 }


### PR DESCRIPTION
After experimenting with mouse support, I added JOY_writeJoypadX(u16 joy, u16 pos) and JOY_writeJoypadY(u16 joy, u16 pos) in order to allow developer to set a specific position for cursor whenever he wants instead of 0,0 by default (e.g. start screen, or potentially for other gameplay features).