### PR TITLE
Clean-up Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,16 @@
-# Ignore git repo
-/.git
-
-# Ignore non-building related directories
-/sample/
+# Ignore non-build related directories
+/.git/
 /doc/
+/sample/
+/vstudio/
+
+# Ignore non-build related files
+/.dockerignore
+/.gitignore
+/build_adv.bat
+/build_lib.bat
+/changelog.txt
+/COPYING.RUNTIME
+/Dockerfile
+/license.txt
+/readme.md


### PR DESCRIPTION
This re-works the Dockerfile to allow for a smaller size (saves about 20 MB) as well as adds ARGs so that new version of SGDK_wine and the JDK version can be tested before permanent changes are made to the Dockerfile. This also now follows some Dockerfile best practices, mainly around minimizing of the number of layers used and apt-get usage to minimize container size see https://docs.docker.com/develop/develop-images/dockerfile_best-practices for details. Tested on various `samples` to make sure it continued to work as expected.