### PR TITLE
Use the correct bits to detect 3-button.

### DIFF
--- a/src/joy.c
+++ b/src/joy.c
@@ -649,9 +649,11 @@ static u16 read6Btn(u16 port)
     v1 = TH_CONTROL_PHASE(pb);                    /* - 0 s a 0 0 d u - 1 c b r l d u */
     val = TH_CONTROL_PHASE(pb);                   /* - 0 s a 0 0 d u - 1 c b r l d u */
     v2 = TH_CONTROL_PHASE(pb);                    /* - 0 s a 0 0 0 0 - 1 c b m x y z */
-    val = TH_CONTROL_PHASE(pb);                   /* - 0 s a 1 1 1 1 - 1 c b r l d u */
+    val = TH_CONTROL_PHASE(pb);                   /* - 0 s a - - - - - 1 c b r l d u */
 
-    if ((val & 0x0F00) != 0x0F00) v2 = (JOY_TYPE_PAD3 << JOY_TYPE_SHIFT) | 0x0F00; /* three button pad */
+    // On a six-button controller, bits 0-3 of the high byte will always read 0.
+    // This corresponds to up + down on a 3-button controller.
+    if ((v2 & 0x0F00) != 0x0000) v2 = (JOY_TYPE_PAD3 << JOY_TYPE_SHIFT) | 0x0F00; /* three button pad */
     else v2 = (JOY_TYPE_PAD6 << JOY_TYPE_SHIFT) | ((v2 & 0x000F) << 8); /* six button pad */
 
     val = ((v1 & 0x3000) >> 6) | (v1 & 0x003F);   /* 0 0 0 0 0 0 0 0 s a c b r l d u  */


### PR DESCRIPTION
Addresses #210 

Per the spec documents linked in the issue, the values of bits 0-4 during the third cycle should be used to distinguish 3-button from 6-button. They will be all zero on 6-button -- this is "impossible" on 3-button as it would correspond to down + up simultaneously.

I have an official sega 6-button that does not consistently set the bits in the fourth cycle to 1, and the docs say this is undefined.

Only drawback is that if `JOY_init` is called while a controller which emulates 3-button but allows for up+down is connected, and up+down are being held, it will misdetect as 6-button. This seems like it's better than mis-detecting an official controller, and it will be properly detected as 3-button as soon as that combination is no longer held. Since the 6-to-3 transition is one way (until you do `JOY_reset` again) this seems preferable as the misdetection of the official controller in the current code will stick.