### PR TITLE
Dockerfile improvement to support building in Apple M1 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM amd64/ubuntu:20.04
 
 # Set-up argument defaults
 ARG JDK_VER=11


### PR DESCRIPTION
This change forces the Docker base image to be amd64 (x86) instead of using the platform default for M1 Macs (ARM).

The SGDK container requires i386 packages that are not available in ARM platform. Docker for Apple silicon allows to build and run x86 images.

With this change, the docker image can be used to build SGDK projects in M1 Macs.