### PR TITLE
fix issue of incorrect transformation

### DIFF
--- a/inc/pal.h
+++ b/inc/pal.h
@@ -32,7 +32,7 @@
  *  \param color
  *      RGB 24 bits color
  */
-#define RGB24_TO_VDPCOLOR(color)    ((((color + 0x100000) >> ((2 * 8) + 4)) & VDPPALETTE_REDMASK) | (((color + 0x1000) >> ((1 * 4) + 4)) & VDPPALETTE_GREENMASK) | (((color + 0x10) << 4) & VDPPALETTE_BLUEMASK))
+#define RGB24_TO_VDPCOLOR(color)    (((((color + 0x100000) < 0xFF0000 ? color + 0x100000 : 0xFF0000) >> (20)) & VDPPALETTE_REDMASK) | (((((color & 0xff00) + 0x1000) < 0xFF00 ? (color & 0xff00) + 0x1000 : 0xFF00) >> ((1 * 4) + 4)) & VDPPALETTE_GREENMASK) | (((((color & 0xff) + 0x10) < 0xFF ? (color & 0xff) + 0x10 : 0xFF) << 4) & VDPPALETTE_BLUEMASK))
 
 
 /**

--- a/inc/pal.h
+++ b/inc/pal.h
@@ -32,7 +32,7 @@
  *  \param color
  *      RGB 24 bits color
  */
-#define RGB24_TO_VDPCOLOR(color)    (((color >> ((2 * 8) + 4)) & VDPPALETTE_REDMASK) | ((color >> ((1 * 4) + 4)) & VDPPALETTE_GREENMASK) | ((color << 4) & VDPPALETTE_BLUEMASK))
+#define RGB24_TO_VDPCOLOR(color)    ((((color + 0x100000) >> ((2 * 8) + 4)) & VDPPALETTE_REDMASK) | (((color + 0x1000) >> ((1 * 4) + 4)) & VDPPALETTE_GREENMASK) | (((color + 0x10) << 4) & VDPPALETTE_BLUEMASK))
 
 
 /**


### PR DESCRIPTION
when the color component was 0xF0 or bigger the macro retorn 0 before this change. Sorry about this mistake.