### PR TITLE
Use objcopy instead of ld to generate rom_head.bin

### DIFF
--- a/makefile.gen
+++ b/makefile.gen
@@ -177,7 +177,7 @@ out/sega.o: $(SRC)/boot/sega.s out/rom_head.bin
 	$(CC) -x assembler-with-cpp $(DEFAULT_FLAGS) -c $(SRC)/boot/sega.s -o $@
 
 out/rom_head.bin: out/rom_head.o
-	$(LD) -T $(GDK)/md.ld -nostdlib --oformat binary -o $@ $<
+	$(OBJCPY) -O binary $< $@
 
 out/rom_head.o: $(SRC)/boot/rom_head.c
 	$(CC) $(DEFAULT_FLAGS) -c $< -o $@

--- a/src/boot/sega.s
+++ b/src/boot/sega.s
@@ -43,7 +43,7 @@ _Vecteurs_68K:
         dc.l    _INT,_INT,_INT,_INT,_INT,_INT,_INT,_INT
 
 rom_header:
-        .incbin "out/rom_head.bin", 0x10, 0x100
+        .incbin "out/rom_head.bin", 0, 0x100
 
 _Entry_Point:
         move    #0x2700,%sr


### PR DESCRIPTION
This avoids the .comment section being also added by ld. This change
should increase compatibility with other GCC toolchains in which ld does
not add the .comment section, and makes sega.s file easier to
understand, because the "esoteric" 16-byte skip from the .incbin
rom_head.bin can now be removed.