### PR TITLE
Build library sources in src/ext

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -5,7 +5,7 @@ LIB := $(GDK)/lib
 
 SRC_LIB := $(GDK)/src
 RES_LIB := $(GDK)/res
-INCLUDE_LIB := $(GDK)/inc
+INCLUDE_LIB := $(GDK)/inc $(GDK)/inc/ext
 MAKEFILE_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 MAKEFILE_DIR := $(subst \,/,$(MAKEFILE_DIR))
 

--- a/makefile.gen
+++ b/makefile.gen
@@ -57,9 +57,10 @@ DEPS:= $(OBJS:.o=.d)
 LST:= $(SRC_C:.c=.lst)
 LSTS:= $(addprefix out/, $(LST))
 
-INCS:= -I$(INCLUDE) -I$(SRC) -I$(RES) -I$(INCLUDE_LIB) -I$(RES_LIB)
+INCS:= -I$(INCLUDE) -I$(SRC) -I$(RES) $(foreach inc, $(INCLUDE_LIB), -I$(inc)) -I$(RES_LIB)
 DEFAULT_FLAGS= $(EXTRA_FLAGS) -DSGDK_GCC -m68000 -Wall -Wextra -Wno-shift-negative-value -Wno-main -Wno-unused-parameter -fno-builtin $(INCS) -B$(BIN)
-FLAGSZ80:= -i$(SRC) -i$(INCLUDE) -i$(RES) -i$(SRC_LIB) -i$(INCLUDE_LIB)
+FLAGSZ80:= -i$(SRC) -i$(INCLUDE) -i$(RES) -i$(RES_LIB) $(foreach inc, $(INCLUDE_LIB), -i$(inc))
+
 
 #release: FLAGS= $(DEFAULT_FLAGS) -Os -fomit-frame-pointer -fuse-linker-plugin -flto
 release: FLAGS= $(DEFAULT_FLAGS) -O3 -fuse-linker-plugin -fno-web -fno-gcse -fno-unit-at-a-time -fomit-frame-pointer -flto

--- a/makelib.gen
+++ b/makelib.gen
@@ -8,9 +8,8 @@ endif
 include $(GDK)/common.mk
 
 SRC_LIB_C := $(wildcard $(SRC_LIB)/*.c)
-SRC_LIB_C += $(wildcard $(SRC_LIB)/*/*.c)
+SRC_LIB_C += $(wildcard $(SRC_LIB)/ext/*/*.c)
 SRC_LIB_S := $(wildcard $(SRC_LIB)/*.s)
-SRC_LIB_S += $(wildcard $(SRC_LIB)/*/*.s)
 SRC_LIB_S80 := $(wildcard $(SRC_LIB)/*.s80)
 
 RES_LIB_RES := $(wildcard $(RES_LIB)/*.res)
@@ -26,9 +25,11 @@ DEP_LIB := $(OBJ_LIB:.o=.d)
 
 LST_LIB := $(SRC_LIB_C:.c=.lst)
 
-INCS_LIB := -I$(INCLUDE_LIB) -I$(SRC_LIB) -I$(RES_LIB)
+INCS_LIB_C := $(foreach incdir, $(INCLUDE_LIB), -I$(incdir))
+INCS_LIB_Z80 := $(foreach incdir, $(INCLUDE_LIB), -i$(incdir))
+INCS_LIB := $(INCS_LIB_C) -I$(SRC_LIB) -I$(RES_LIB)
 DEFAULT_FLAGS_LIB := $(EXTRA_FLAGS) -DSGDK_GCC -m68000 -Wall -Wextra -Wno-shift-negative-value -fno-builtin -Wno-unused-parameter $(INCS_LIB) -B$(BIN)
-FLAGSZ80_LIB := -i$(SRC_LIB) -i$(INCLUDE_LIB)
+FLAGSZ80_LIB := -i$(SRC_LIB) $(INCS_LIB_Z80)
 
 
 #release: FLAGS_LIB= $(DEFAULT_FLAGS_LIB) -Os -fomit-frame-pointer -fuse-linker-plugin -flto


### PR DESCRIPTION
These changes add to the library all sources in `src/ext`, and also ensure the includes in `inc/ext` are passed to GCC during builds.