### PR TITLE
Add ZGM support to xgmtool

### DIFF
--- a/tools/xgmtool/inc/compress.h
+++ b/tools/xgmtool/inc/compress.h
@@ -1,0 +1,11 @@
+
+typedef struct
+{
+    uint8_t nextb;
+    uint8_t *out;
+    uint8_t *outptr;
+    size_t out_l;
+} lz77_compress_t;
+
+size_t lz77c_compress_buf(unsigned char *in, size_t inlen, void **pout);
+

--- a/tools/xgmtool/inc/lz77.h
+++ b/tools/xgmtool/inc/lz77.h
@@ -1,0 +1,25 @@
+/* This file is part of hwzip from https://www.hanshq.net/zip.html
+   It is put in the public domain; see the LICENSE file for details. */
+
+#ifndef LZ77_H
+#define LZ77_H
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#define LZ_WND_SIZE 32768
+
+/* Perform LZ77 compression on the src_len bytes in src, with back references
+   limited to a certain maximum distance and length, and with or without
+   self-overlap. Returns false as soon as either of the callback functions
+   returns false, otherwise returns true when all bytes have been processed. */
+bool lz77_compress(const uint8_t *src, size_t src_len,
+                   size_t max_dist, size_t max_len, bool allow_overlap,
+                   bool (*lit_callback)(uint8_t lit, void *aux),
+                   bool (*backref_callback)(size_t dist, size_t len, void *aux),
+                   void *aux);
+
+#endif

--- a/tools/xgmtool/inc/vgm.h
+++ b/tools/xgmtool/inc/vgm.h
@@ -53,6 +53,6 @@ Sample* VGM_getSample(VGM* vgm, int sampleOffset);
 void VGM_convertWaits(VGM* vgm);
 //void VGM_shiftSamples(VGM* vgm, int sft);
 unsigned char* VGM_asByteArray(VGM* vgm, int* outSize);
-
+unsigned char* VGM_asByteArray2(VGM* vgm, int* outSize, unsigned char **dataBl, int *dataBlSize);
 
 #endif // VGM_H_

--- a/tools/xgmtool/src/compress.c
+++ b/tools/xgmtool/src/compress.c
@@ -1,0 +1,76 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include "../inc/lz77.h"
+#include "../inc/compress.h"
+
+void lz77c_init(lz77_compress_t* s, uint8_t*out)
+{
+    memset(s, 0, sizeof(*s));
+    s->nextb = 0;
+    s->out = out;
+    s->outptr = out;
+    s->out_l = 1;
+}
+
+bool lz77c_check_flush(lz77_compress_t* s)
+{
+    s->nextb = (s->nextb + 1) & 7;
+    if (!s->nextb) {
+        s->outptr += s->out_l;
+        s->outptr[0] = 0;
+        s->out_l = 1;
+    }
+    return true;
+}
+
+bool lz77c_lit_callback(uint8_t lit, void* aux)
+{
+    lz77_compress_t* s = aux;
+
+    s->outptr[0] = (s->outptr[0] >> 1);
+    s->outptr[s->out_l++] = lit;
+
+    return lz77c_check_flush(s);
+}
+
+bool lz77c_backref_callback(size_t dist, size_t len, void* aux)
+{
+    lz77_compress_t* s = aux;
+
+    s->outptr[0] = (s->outptr[0] >> 1) | 0x80;
+    s->outptr[s->out_l++] = ((dist-1) >> 8) & 0xff;
+    s->outptr[s->out_l++] = ((dist-1) >> 0) & 0xff;
+    s->outptr[s->out_l++] = (len-1) & 0xff;
+
+    return lz77c_check_flush(s);
+}
+
+void lz77c_finish(lz77_compress_t* s)
+{
+    s->outptr[0] = ((s->outptr[0] >> 1) | 0x80) >> (7 - s->nextb);
+    s->outptr[s->out_l++] = 0;
+    s->outptr[s->out_l++] = 0;
+    s->outptr[s->out_l++] = 0;
+    s->outptr += s->out_l;
+}
+
+size_t lz77c_compress_buf(unsigned char *in, size_t inlen, void **pout)
+{
+    bool res;
+    lz77_compress_t s;
+    unsigned char *out;
+
+    out = (unsigned char*)malloc((inlen * 10) / 8 + 4);
+
+    lz77c_init(&s, out);
+    res = lz77_compress(in, inlen, 32 * 1024, 256, true, lz77c_lit_callback, lz77c_backref_callback, &s);
+    lz77c_finish(&s);
+
+    if (!res) {
+        free(out);
+        return 0;
+    }
+
+    *pout = (void *)s.out;
+    return s.outptr - s.out;
+}

--- a/tools/xgmtool/src/lz77.c
+++ b/tools/xgmtool/src/lz77.c
@@ -1,0 +1,247 @@
+/* This file is part of hwzip from https://www.hanshq.net/zip.html
+   It is put in the public domain; see the LICENSE file for details. */
+
+#include "../inc/lz77.h"
+
+#include <assert.h>
+#include <limits.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define HASH_SIZE 15
+#define NO_POS    SIZE_MAX
+#define MIN_LEN   4
+
+/* Compare the substrings starting at src[i] and src[j], and return the length
+ * of the common prefix if it is strictly longer than prev_match_len
+ * and shorter or equal to max_match_len, otherwise return zero. */
+static size_t cmp(const uint8_t* src, size_t i, size_t j,
+    size_t prev_match_len, size_t max_match_len)
+{
+    size_t l;
+
+    assert(prev_match_len < max_match_len);
+
+    /* Check whether the first prev_match_len + 1 characters match. Do this
+     * backwards for a higher chance of finding a mismatch quickly. */
+    for (l = 0; l < prev_match_len + 1; l++) {
+        if (src[i + prev_match_len - l] !=
+            src[j + prev_match_len - l]) {
+            return 0;
+        }
+    }
+
+    assert(l == prev_match_len + 1);
+
+    /* Now check how long the full match is. */
+    for (; l < max_match_len; l++) {
+        if (src[i + l] != src[j + l]) {
+            break;
+        }
+    }
+
+    assert(l > prev_match_len);
+    assert(l <= max_match_len);
+    assert(memcmp(&src[i], &src[j], l) == 0);
+
+    return l;
+}
+
+static inline size_t min(size_t a, size_t b)
+{
+    return a < b ? a : b;
+}
+
+/* Find the longest most recent string which matches the string starting
+ * at src[pos]. The match must be strictly longer than prev_match_len and
+ * shorter or equal to max_match_len. Returns the length of the match if found
+ * and stores the match position in *match_pos, otherwise returns zero. */
+static size_t find_match(const uint8_t* src, size_t pos, uint32_t hash,
+    size_t max_dist, size_t prev_match_len, size_t max_match_len, bool allow_overlap,
+    const size_t* head, const size_t* prev, size_t* match_pos)
+{
+    size_t max_match_steps = 4096;
+    size_t i, l;
+    bool found;
+    size_t max_cmp;
+
+    if (prev_match_len == 0) {
+        /* We want backrefs of length MIN_LEN or longer. */
+        prev_match_len = MIN_LEN - 1;
+    }
+
+    if (prev_match_len >= max_match_len) {
+        /* A longer match would be too long. */
+        return 0;
+    }
+
+    if (prev_match_len >= 32) {
+        /* Do not try too hard if there is already a good match. */
+        max_match_steps /= 4;
+    }
+
+    found = false;
+    i = head[hash];
+    max_cmp = max_match_len;
+
+    /* Walk the linked list of prefix positions. */
+    for (i = head[hash]; i != NO_POS; i = prev[i % LZ_WND_SIZE]) {
+        if (max_match_steps == 0) {
+            break;
+        }
+        max_match_steps--;
+
+        assert(i < pos && "Matches should precede pos.");
+        if (pos - i > max_dist) {
+            /* The match is too far back. */
+            break;
+        }
+
+        if (!allow_overlap) {
+            max_cmp = min(max_match_len, pos - i);
+            if (max_cmp <= prev_match_len) {
+                continue;
+            }
+        }
+
+        l = cmp(src, i, pos, prev_match_len, max_cmp);
+
+        if (l != 0) {
+            assert(l > prev_match_len);
+            assert(l <= max_match_len);
+
+            found = true;
+            *match_pos = i;
+            prev_match_len = l;
+
+            if (l == max_match_len) {
+                /* A longer match is not possible. */
+                return l;
+            }
+        }
+    }
+
+    if (!found) {
+        return 0;
+    }
+
+    return prev_match_len;
+}
+
+/* Compute a hash value based on four bytes pointed to by ptr. */
+static inline uint32_t read32le(const uint8_t* p)
+{
+    return ((uint32_t)p[0] << 0) |
+        ((uint32_t)p[1] << 8) |
+        ((uint32_t)p[2] << 16) |
+        ((uint32_t)p[3] << 24);
+}
+
+static uint32_t hash4(const uint8_t* ptr)
+{
+    static const uint32_t HASH_MUL = 2654435761U;
+
+    /* Knuth's multiplicative hash. */
+    return (read32le(ptr) * HASH_MUL) >> (32 - HASH_SIZE);
+}
+
+static void insert_hash(uint32_t hash, size_t pos, size_t* head, size_t* prev)
+{
+    assert(pos != NO_POS && "Invalid pos!");
+    prev[pos % LZ_WND_SIZE] = head[hash];
+    head[hash] = pos;
+}
+
+bool lz77_compress(const uint8_t* src, size_t src_len, size_t max_dist,
+    size_t max_len, bool allow_overlap,
+    bool (*lit_callback)(uint8_t lit, void* aux),
+    bool (*backref_callback)(size_t dist, size_t len, void* aux),
+    void* aux)
+{
+    size_t head[1U << HASH_SIZE];
+    size_t prev[LZ_WND_SIZE];
+
+    uint32_t h;
+    size_t i, j, dist;
+    size_t match_len, match_pos;
+    size_t prev_match_len, prev_match_pos;
+
+    /* Initialize the hash table. */
+    for (i = 0; i < sizeof(head) / sizeof(head[0]); i++) {
+        head[i] = NO_POS;
+    }
+
+    prev_match_len = 0;
+    prev_match_pos = NO_POS;
+
+    for (i = 0; i + MIN_LEN - 1 < src_len; i++) {
+        /* Search for a match using the hash table. */
+        h = hash4(&src[i]);
+        match_len = find_match(src, i, h, max_dist, prev_match_len,
+            min(max_len, src_len - i), allow_overlap,
+            head, prev, &match_pos);
+
+        /* Insert the current hash for future searches. */
+        insert_hash(h, i, head, prev);
+
+        /* If the previous match is at least as good as the current. */
+        if (prev_match_len != 0 && prev_match_len >= match_len) {
+            /* Output the previous match. */
+            dist = (i - 1) - prev_match_pos;
+            if (!backref_callback(dist, prev_match_len, aux)) {
+                return false;
+            }
+            /* Move past the match. */
+            for (j = i + 1; j < min((i - 1) + prev_match_len,
+                src_len - (MIN_LEN - 1)); j++) {
+                h = hash4(&src[j]);
+                insert_hash(h, j, head, prev);
+            }
+            i = (i - 1) + prev_match_len - 1;
+            prev_match_len = 0;
+            continue;
+        }
+
+        /* If no match (and no previous match), output literal. */
+        if (match_len == 0) {
+            assert(prev_match_len == 0);
+            if (!lit_callback(src[i], aux)) {
+                return false;
+            }
+            continue;
+        }
+
+        /* Otherwise the current match is better than the previous. */
+
+        if (prev_match_len != 0) {
+            /* Output a literal instead of the previous match. */
+            if (!lit_callback(src[i - 1], aux)) {
+                return false;
+            }
+        }
+
+        /* Defer this match and see if the next is even better. */
+        prev_match_len = match_len;
+        prev_match_pos = match_pos;
+    }
+
+    /* Output any previous match. */
+    if (prev_match_len != 0) {
+        dist = (i - 1) - prev_match_pos;
+        if (!backref_callback(dist, prev_match_len, aux)) {
+            return false;
+        }
+        i = (i - 1) + prev_match_len;
+    }
+
+    /* Output any remaining literals. */
+    for (; i < src_len; i++) {
+        if (!lit_callback(src[i], aux)) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/tools/xgmtool/src/vgm.c
+++ b/tools/xgmtool/src/vgm.c
@@ -1984,6 +1984,8 @@ unsigned char* VGM_asByteArray2(VGM* vgm, int* outSize, unsigned char **dataBl, 
         fwrite(data, 1, i, f);
     }
 
+    fflush(f);
+
     unsigned char* array = inEx(f, 0, getFileSizeEx(f), outSize);
 
     fclose(f);

--- a/tools/xgmtool/src/xgmtool.c
+++ b/tools/xgmtool/src/xgmtool.c
@@ -172,11 +172,26 @@ int main(int argc, char *argv[ ])
             // VGM output
             if (!strcasecmp(outExt, "VGM"))
             {
-                // get byte array
-                outData = VGM_asByteArray(vgm, &outDataSize);
-                if (outData == NULL) exit(1);
-                // write to file
-                writeBinaryFile(outData, outDataSize, argv[2]);
+                if (argc >= 4)
+                {
+                    // get byte array
+                    unsigned char *outData2;
+                    int outDataSize2;
+
+                    outData = VGM_asByteArray2(vgm, &outDataSize, &outData2, &outDataSize2);
+                    if (outData == NULL) exit(1);
+
+                    // write to file
+                    writeBinaryFile(outData, outDataSize, argv[2]);
+                    writeBinaryFile(outData2, outDataSize2, argv[3]);
+                }
+                else {
+                    // get byte array
+                    outData = VGM_asByteArray(vgm, &outDataSize);
+                    if (outData == NULL) exit(1);
+                    // write to file
+                    writeBinaryFile(outData, outDataSize, argv[2]);
+                }
             }
             else
             {

--- a/tools/xgmtool/src/xgmtool.c
+++ b/tools/xgmtool/src/xgmtool.c
@@ -8,6 +8,7 @@
 #include "../inc/vgm.h"
 #include "../inc/xgm.h"
 #include "../inc/xgc.h"
+#include "../inc/compress.h"
 
 #define SYSTEM_AUTO     -1
 #define SYSTEM_NTSC     0
@@ -139,7 +140,7 @@ int main(int argc, char *argv[ ])
     // VGM or empty (assumed as VGM)
     if (!strcasecmp(inExt, "VGM") || !strlen(inExt))
     {
-        if ((!strcasecmp(outExt, "VGM")) || (!strcasecmp(outExt, "XGM")) || (!strcasecmp(outExt, "BIN")) || (!strcasecmp(outExt, "XGC")))
+        if ((!strcasecmp(outExt, "VGM")) || (!strcasecmp(outExt, "XGM")) || (!strcasecmp(outExt, "BIN")) || (!strcasecmp(outExt, "XGC")) || (!strcasecmp(outExt, "ZGM")))
         {
             // VGM optimization
             int inDataSize;
@@ -172,26 +173,36 @@ int main(int argc, char *argv[ ])
             // VGM output
             if (!strcasecmp(outExt, "VGM"))
             {
-                if (argc >= 4)
-                {
-                    // get byte array
-                    unsigned char *outData2;
-                    int outDataSize2;
+                // get byte array
+                outData = VGM_asByteArray(vgm, &outDataSize);
+                if (outData == NULL) exit(1);
+                // write to file
+                writeBinaryFile(outData, outDataSize, argv[2]);
+            }
+            else if (!strcasecmp(outExt, "ZGM"))
+            {
+                // get byte array
+                unsigned char *outData2;
+                int outDataSize2;
+                unsigned char *lz;
+                int lzsize;
+                FILE *fp;
 
-                    outData = VGM_asByteArray2(vgm, &outDataSize, &outData2, &outDataSize2);
-                    if (outData == NULL) exit(1);
+                // split VGM command stream and PCM data blocks
+                outData = VGM_asByteArray2(vgm, &outDataSize, &outData2, &outDataSize2);
+                if (outData == NULL) exit(1);
 
-                    // write to file
-                    writeBinaryFile(outData, outDataSize, argv[2]);
-                    writeBinaryFile(outData2, outDataSize2, argv[3]);
-                }
-                else {
-                    // get byte array
-                    outData = VGM_asByteArray(vgm, &outDataSize);
-                    if (outData == NULL) exit(1);
-                    // write to file
-                    writeBinaryFile(outData, outDataSize, argv[2]);
-                }
+                // compress VGM stream
+                lzsize = lz77c_compress_buf(outData, outDataSize, (void **)&lz);
+                if (lz == NULL) exit(1);
+
+                // write to file
+                fp = fopen(argv[2], "wb");
+                fwrite(lz, 1, lzsize, fp);
+                fwrite(outData2, 1, outDataSize2, fp);
+                fclose(fp);
+
+                free(lz);
             }
             else
             {


### PR DESCRIPTION
The new ZGM format is primarily intended to be used for 32X games, with VGM streams being LZ77-compressed with 32KiB window and PCM data blocks appended after the stream. You can find the reference implementation of the player is Doom 32X Resurrection source code: https://github.com/viciious/d32xr

The LZ77 implementation is public domain.