### PR TITLE
Added a bunch of VDPSprite useful functions

### DIFF
--- a/inc/vdp_spr.h
+++ b/inc/vdp_spr.h
@@ -314,6 +314,125 @@ VDPSprite* VDP_linkSprites(u16 index, u16 num);
  *  \see VDP_refreshHighestAllocatedSpriteIndex()
  */
 void VDP_updateSprites(u16 num, TransferMethod tm);
-
+/**
+ *  \brief
+ *      Set sprite priority (use sprite list cache).
+ *
+ *  \param index
+ *      Index of the sprite to modify attributes (should be < MAX_VDP_SPRITE).
+ *  \param priority
+ *      sprite priority. Valid values: 0 -> low, 1 -> high
+ *
+ *  \see VDP_setSprite(..)
+ *  \see VDP_updateSprites(..)
+ */
+void VDP_setSpritePriority(u16 index, bool priority);
+/**
+ *  \brief
+ *      Get sprite priority (use sprite list cache).
+ *
+ *  \param index
+ *      Index of the sprite to modify attributes (should be < MAX_VDP_SPRITE).
+ */
+bool VDP_getSpritePriority(u16 index);
+/**
+ *  \brief
+ *      Set sprite palette (use sprite list cache).
+ *
+ *  \param index
+ *      Index of the sprite to modify attributes (should be < MAX_VDP_SPRITE).
+ *  \param palette
+ *      palette index. Valid values: [0, 3]
+ *
+ *  \see VDP_setSprite(..)
+ *  \see VDP_updateSprites(..)
+ */
+void VDP_setSpritePalette(u16 index, u16 palette);
+/**
+ *  \brief
+ *      Get sprite palette (use sprite list cache).
+ *
+ *  \param index
+ *      Index of the sprite to modify attributes (should be < MAX_VDP_SPRITE).
+ */
+u16 VDP_getSpritePalette(u16 index);
+/**
+ *  \brief
+ *      Set sprite horizontal and vertical flip (use sprite list cache).
+ *
+ *  \param index
+ *      Index of the sprite to modify attributes (should be < MAX_VDP_SPRITE).
+ *  \param flipH
+ *      Horizontal flip. Valid values: 0 -> normal, 1 -> flipped.
+ *  \param flipV
+ *      Vertical flip. Valid values: 0 -> normal, 1 -> flipped.
+ *
+ *  \see VDP_setSprite(..)
+ *  \see VDP_updateSprites(..)
+ */
+void VDP_setSpriteFlip(u16 index, bool flipH, bool flipV);
+/**
+ *  \brief
+ *      Set sprite horizontal flip (use sprite list cache).
+ *
+ *  \param index
+ *      Index of the sprite to modify attributes (should be < MAX_VDP_SPRITE).
+ *  \param flipH
+ *      Horizontal flip. Valid values: 0 -> normal, 1 -> flipped.
+ *
+ *  \see VDP_setSprite(..)
+ *  \see VDP_updateSprites(..)
+ */
+void VDP_setSpriteFlipH(u16 index, bool flipH);
+/**
+ *  \brief
+ *      Set sprite vertical flip (use sprite list cache).
+ *
+ *  \param index
+ *      Index of the sprite to modify attributes (should be < MAX_VDP_SPRITE).
+ *  \param flipV
+ *      Vertical flip. Valid values: 0 -> normal, 1 -> flipped.
+ *
+ *  \see VDP_setSprite(..)
+ *  \see VDP_updateSprites(..)
+ */
+void VDP_setSpriteFlipV(u16 index, bool flipV);
+/**
+ *  \brief
+ *      Get sprite horizontal flip (use sprite list cache).
+ *
+ *  \param index
+ *      Index of the sprite to modify attributes (should be < MAX_VDP_SPRITE).
+ */
+bool VDP_getSpriteFlipH(u16 index);
+/**
+ *  \brief
+ *      Get sprite vertical flip (use sprite list cache).
+ *
+ *  \param index
+ *      Index of the sprite to modify attributes (should be < MAX_VDP_SPRITE).
+ */
+bool VDP_getSpriteFlipV(u16 index);
+/**
+ *  \brief
+ *      Set sprite tile index (use sprite list cache).
+ *
+ *  \param index
+ *      Index of the sprite to modify attributes (should be < MAX_VDP_SPRITE).
+ *  \param tile
+ *      Tile index. Valid values: [0, 2047].
+ *
+ *  \see VDP_setSprite(..)
+ *  \see VDP_updateSprites(..)
+ */
+void VDP_setSpriteTile(u16 index, u16 tile);
+/**
+ *  \brief
+ *      Get sprite tile index (use sprite list cache).
+ *
+ *  \param index
+ *      Index of the sprite to modify attributes (should be < MAX_VDP_SPRITE).
+ */
+u16 VDP_getSpriteTile(u16 index);
 
 #endif // _VDP_SPR_H_

--- a/src/vdp_spr.c
+++ b/src/vdp_spr.c
@@ -233,6 +233,63 @@ void VDP_updateSprites(u16 num, TransferMethod tm)
     DMA_transfer(tm, DMA_VRAM, vdpSpriteCache, VDP_SPRITE_TABLE, (sizeof(VDPSprite) * num) / 2, 2);
 }
 
+void VDP_setSpritePriority(u16 index, bool priority)
+{
+    vdpSpriteCache[index].priority = priority;
+}
+
+bool VDP_getSpritePriority(u16 index)
+{
+    return vdpSpriteCache[index].priority == 1;
+}
+
+void VDP_setSpritePalette(u16 index, u16 palette)
+{
+    vdpSpriteCache[index].palette = palette;
+}
+
+u16 VDP_getSpritePalette(u16 index)
+{
+    return vdpSpriteCache[index].palette;
+}
+
+void VDP_setSpriteFlip(u16 index, bool flipH, bool flipV)
+{
+    VDPSprite *sprite = &vdpSpriteCache[index];
+    sprite->flipH = flipH;
+    sprite->flipV = flipV;
+}
+
+void VDP_setSpriteFlipH(u16 index, bool flipH)
+{
+    vdpSpriteCache[index].flipH = flipH;
+}
+
+void VDP_setSpriteFlipV(u16 index, bool flipV)
+{
+    vdpSpriteCache[index].flipH = flipV;
+}
+
+bool VDP_getSpriteFlipH(u16 index)
+{
+    return vdpSpriteCache[index].flipH != 0;
+}
+
+bool VDP_getSpriteFlipV(u16 index)
+{
+    return vdpSpriteCache[index].flipV != 0;
+}
+
+void VDP_setSpriteTile(u16 index, u16 tile)
+{
+    vdpSpriteCache[index].tile = tile;
+}
+
+u16 VDP_getSpriteTile(u16 index)
+{
+    return vdpSpriteCache[index].tile;
+}
+
 void logVDPSprite(u16 index)
 {
     char str[64];


### PR DESCRIPTION
I have these functions defined in my game, and I think they may be useful to more people:

 - void VDP_setSpritePriority(u16 index, bool priority);
 - bool VDP_getSpritePriority(u16 index);
 - void VDP_setSpritePalette(u16 index, u16 palette);
 - u16 VDP_getSpritePalette(u16 index);
 - void VDP_setSpriteFlip(u16 index, bool flipH, bool flipV);
 - void VDP_setSpriteFlipH(u16 index, bool flipH);
 - void VDP_setSpriteFlipV(u16 index, bool flipV);
 - bool VDP_getSpriteFlipH(u16 index);
 - bool VDP_getSpriteFlipV(u16 index);
 - void VDP_setSpriteTile(u16 index, u16 tile);
 - u16 VDP_getSpriteTile(u16 index);

I have some doubts about using u16 (instead of u8) for the palette functions. What do you think is better?
