### PR TITLE
Fix xgmtool compilation on Linux

### DIFF
--- a/tools/xgmtool/src/xgmtool.c
+++ b/tools/xgmtool/src/xgmtool.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
xgmtool.c was missing stdint.h, causing the following compile error on Linux:

```
In file included from src/xgmtool.c:11:
src/../inc/compress.h:4:5: error: unknown type name ‘uint8_t’
    4 |     uint8_t nextb;
      |     ^~~~~~~
src/../inc/compress.h:5:5: error: unknown type name ‘uint8_t’
    5 |     uint8_t *out;
      |     ^~~~~~~
src/../inc/compress.h:6:5: error: unknown type name ‘uint8_t’
    6 |     uint8_t *outptr;
      |     ^~~~~~~
```

(I used `gcc src/*.c -Iinc -Isrc -o xgmtool -lm` from tools/xgmtool directory to build)