### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ ENV GDK=/sgdk
 ENV SGDK_DOCKER=y
 
 # Create wrappers to execute .exe files using wine
-RUN /sgdk/bin/create-bin-wrappers.sh
+RUN sed -i 's/\r$//' sgdk/bin/create-bin-wrappers.sh && \  
+        chmod +x sgdk/bin/create-bin-wrappers.sh
 
 # Set-up mount point and make command
 VOLUME /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ ENV SGDK_DOCKER=y
 # Create wrappers to execute .exe files using wine
 RUN sed -i 's/\r$//' sgdk/bin/create-bin-wrappers.sh && \  
         chmod +x sgdk/bin/create-bin-wrappers.sh
+        
+RUN sgdk/bin/create-bin-wrappers.sh
 
 # Set-up mount point and make command
 VOLUME /src


### PR DESCRIPTION
Encountered encoding issue while testing docker image on Ubuntu instead of Windows previously. 
It suggested that create-bin-wrappers.sh did not exist.  
Solved by using sed, as depicted in a solution from Utkarsh Yeolekar https://stackoverflow.com/posts/45973799/revisions
I built sonic example without any issue.