### PR TITLE
Fix rescomp TMX map priority parsing

### DIFF
--- a/tools/rescomp/src/sgdk/rescomp/type/TMX.java
+++ b/tools/rescomp/src/sgdk/rescomp/type/TMX.java
@@ -206,7 +206,7 @@ public class TMX
                 // get low priority map data in mapData1
                 mapData1 = getMapData(lowPriorityLayer, w, h, file);
                 // get high priority map data in mapData2
-                mapData2 = getMapData(lowPriorityLayer, w, h, file);
+                mapData2 = getMapData(highPriorityLayer, w, h, file);
             }
 
             final Set<TSXTileset> usedTilesetsSet = new HashSet<>();


### PR DESCRIPTION
rescomp wasn't properly getting high priority layer data from a TMX map using the "layer name + low/high" priority definition. This seems to fix it.