### PR TITLE
Clarity improvements & fix for line counter

### DIFF
--- a/tools/rescomp/src/sgdk/rescomp/Compiler.java
+++ b/tools/rescomp/src/sgdk/rescomp/Compiler.java
@@ -125,7 +125,7 @@ public class Compiler
             return false;
         }
 
-        int lineCnt = 1;
+        int lineCnt = 0;
         int align = -1;
         boolean group = true;
         boolean near = false;
@@ -758,7 +758,7 @@ public class Compiler
             }
 
             System.out.println("Resource: " + input);
-            System.out.print("--> executing plugin " + type + "...");
+            System.out.println("--> executing plugin " + type + "...");
 
             return processor.execute(fields);
         }


### PR DESCRIPTION
* fixed line counter variable used when reporting errors while parsing `.res` files. The variable `lineCnt` is initialized to 1 but it gets incremented before being used to display potential errors while parsing a line;
* improved clarity of console messages by using `println` instead of `print`. This avoids some confusion when reading console messages like this:
`--> executing plugin SPRITE...Info: 'spr_face_dead_palette_data' has same content as 'spr_rect_bb_palette_data'`