### PR TITLE
Improved support for newer Linux based GCC tools

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -46,7 +46,7 @@ else
 		LIBGCC := $(LIB)/libgcc.a
 	else
 		# Native Linux
-		PREFIX := m68k-elf-
+		PREFIX ?= m68k-elf-
 		SHELL = sh
 		RM = rm
 		CP = cp

--- a/makefile.gen
+++ b/makefile.gen
@@ -140,7 +140,7 @@ out/symbol.txt: out/rom.out
 	$(NM) $(LTO_PLUGIN) -n out/rom.out > out/symbol.txt
 
 out/rom.out: out/sega.o out/cmd_ $(LIBMD)
-	$(CC) -B$(BIN) -n -T $(GDK)/md.ld -nostdlib out/sega.o @out/cmd_ $(LIBMD) $(LIBGCC) -o out/rom.out -Wl,--gc-sections
+	$(CC) -m68000 -B$(BIN) -n -T $(GDK)/md.ld -nostdlib out/sega.o @out/cmd_ $(LIBMD) $(LIBGCC) -o out/rom.out -Wl,--gc-sections -flto
 	$(RM) out/cmd_
 
 out/cmd_: $(OBJS)

--- a/makelib.gen
+++ b/makelib.gen
@@ -36,7 +36,7 @@ FLAGSZ80_LIB := -i$(SRC_LIB) -i$(INCLUDE_LIB)
 
 
 #release: FLAGS_LIB= $(DEFAULT_FLAGS_LIB) -Os -fomit-frame-pointer -fuse-linker-plugin -flto
-release: FLAGS_LIB= $(DEFAULT_FLAGS_LIB) -O3 -fuse-linker-plugin -fno-web -fno-gcse -fno-unit-at-a-time -fomit-frame-pointer -flto
+release: FLAGS_LIB= $(DEFAULT_FLAGS_LIB) -O3 -fuse-linker-plugin -fno-web -fno-gcse -fno-unit-at-a-time -fomit-frame-pointer -ffat-lto-objects -flto
 release: CFLAGS_LIB= $(FLAGS_LIB)
 release: AFLAGS_LIB= $(FLAGS_LIB)
 release: $(LIB)/libmd.a

--- a/src/string.c
+++ b/src/string.c
@@ -20,8 +20,8 @@
 #define P10 10000000000
 
 #if (ENABLE_NEWLIB == 0)
-static const char const uppercase_hexchars[] = "0123456789ABCDEF";
-static const char const lowercase_hexchars[] = "0123456789abcdef";
+static const char uppercase_hexchars[] = "0123456789ABCDEF";
+static const char lowercase_hexchars[] = "0123456789abcdef";
 #endif  // ENABLE_NEWLIB
 static const char digits[] =
     "0001020304050607080910111213141516171819"


### PR DESCRIPTION
1. makelib.gen: Added -ffat-lto-objects to library compile options. Without this, newer linkers strip vital symbols which cause the final link to fail.
2. makefile.gen: Added -flto to final link stage. Also added -m68000 as some newer linkers generate non-68k code without this which cause runtime exceptions.
3. common.mk: Changed PREFIX setting from := to ?= so it can be overridden from an environment variable.
4. Fixed compiler warnings in string.c. Double use of const.

Changes have been confirmed to work in the default Windows environment.