### PR TITLE
New u16 and u32 to BCD conversion routines.

### DIFF
--- a/inc/maths.h
+++ b/inc/maths.h
@@ -794,15 +794,6 @@ fastfix32 fastFix32Div(fastfix32 val1, fastfix32 val2);
 
 /**
  *  \brief
- *      Binary to Decimal conversion.
- *
- *  \param value
- *      Value to convert.
- */
-u32 intToBCD(u32 value);
-
-/**
- *  \brief
  *      Convert u16 to BCD.
  *
  *  \param value

--- a/inc/maths.h
+++ b/inc/maths.h
@@ -802,6 +802,24 @@ fastfix32 fastFix32Div(fastfix32 val1, fastfix32 val2);
 u32 intToBCD(u32 value);
 
 /**
+ *  \brief
+ *      Convert u16 to BCD.
+ *
+ *  \param value
+ *      u16 value to convert.
+ */
+u32 u16ToBCD(u16 value);
+
+/**
+ *  \brief
+ *      Convert u32 to BCD.
+ *
+ *  \param value
+ *      u32 value to convert.
+ */
+u32 u32ToBCD(u32 value);
+
+/**
  *  \deprecated
  *      Use #getApproximatedDistance(..) instead.
  */

--- a/src/maths.c
+++ b/src/maths.c
@@ -336,44 +336,34 @@ FORCE_INLINE fastfix32 fastFix32Div(fastfix32 val1, fastfix32 val2)
     return v1 / v2;
 }
 
+u32 u16ToBCD(u16 value)
+{
+    u32 res = 0;
+    u8 multiplier = 0;
 
-u32 intToBCD(u32 value)
+    while (value)
+    {
+        res |= modu(value, 10) << multiplier;
+        value = divu(value, 10);
+        multiplier += 4;
+    }
+
+    return res;
+}
+
+u32 u32ToBCD(u32 value)
 {
     if (value > 99999999) return 0x99999999;
-
     if (value < 100) return cnv_bcd_tab[value];
 
-    u32 v;
-    u32 res;
-    u16 carry;
-    u16 cnt;
+    u32 res = 0;
+    u8 multiplier = 0;
 
-    v = value;
-    res = 0;
-    carry = 0;
-    cnt = 4;
-
-    while(cnt--)
+    while (value)
     {
-        u16 bcd = (v & 0xFF) + carry;
-
-        if (bcd > 199)
-        {
-            carry = 2;
-            bcd -= 200;
-        }
-        else if (bcd > 99)
-        {
-            carry = 1;
-            bcd -= 100;
-        }
-        else carry = 0;
-
-        if (bcd)
-            res |= cnv_bcd_tab[bcd] << ((3 - cnt) * 8);
-
-        // next byte
-        v >>= 8;
+        res |= (value % 10) << multiplier;
+        value /= 10;
+        multiplier += 4;
     }
 
     return res;


### PR DESCRIPTION
_intToBCD()_ does not work correctly. A quick test is to pass in 256, the BCD output is 0x100 rather than 0x256. Instead of trying to debug and fix this routine I offer 2 new routines _u16ToBCD()_ and _u32ToBCD()_. The _u16ToBCD()_ routine uses 68K mod and div for speed optimization, while the _u32ToBCD()_ uses normal C-style operations.

Feel free to decline these changes in favor of fixing intToBCD().

Cheers,
IH.
