### PR TITLE
Added CMakeLists.txt to create SGDK libs and host based utilities.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,114 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(md C ASM)
+
+# Set the compiler prefix
+if(DEFINED ENV{PREFIX})
+  set(PREFIX "$ENV{PREFIX}")
+endif()
+
+# Check for sjasm submodule
+if(NOT IS_DIRECTORY "${PROJECT_SOURCE_DIR}/tools/sjasm")
+  find_package(Git)
+  if(Git_FOUND)
+    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init
+                            --recursive ${PROJECT_SOURCE_DIR})
+  else()
+    message(CHECK_FAIL "Could not find git executable")
+  endif()
+endif()
+
+include(ExternalProject)
+ExternalProject_Add(
+  BINTOS
+  SOURCE_DIR ${PROJECT_SOURCE_DIR}/tools/bintos/src
+  BINARY_DIR ${PROJECT_SOURCE_DIR}/tools/bintos/src/build
+  INSTALL_COMMAND install bintos ${PROJECT_SOURCE_DIR}/bin
+  BUILD_ALWAYS TRUE)
+ExternalProject_Add(
+  XGMTOOL
+  SOURCE_DIR ${PROJECT_SOURCE_DIR}/tools/xgmtool/src
+  BINARY_DIR ${PROJECT_SOURCE_DIR}/tools/xgmtool/src/build
+  INSTALL_COMMAND install xgmtool ${PROJECT_SOURCE_DIR}/bin
+  BUILD_ALWAYS TRUE)
+ExternalProject_Add(
+  SJASM
+  CONFIGURE_COMMAND ""
+  DOWNLOAD_COMMAND ""
+  BUILD_COMMAND make -C ${PROJECT_SOURCE_DIR}/tools/sjasm/Sjasm
+  INSTALL_COMMAND install ${PROJECT_SOURCE_DIR}/tools/sjasm/Sjasm/sjasm
+                  ${PROJECT_SOURCE_DIR}/bin
+  BUILD_ALWAYS TRUE)
+
+# Set the compiler/assembler name
+set(CMAKE_C_COMPILER ${PREFIX}gcc)
+set(CMAKE_ASM_COMPILER ${PREFIX}gcc)
+set(CMAKE_AR ${PREFIX}ar)
+
+include_directories(${PROJECT_SOURCE_DIR}/inc)
+include_directories(${PROJECT_SOURCE_DIR}/res)
+include_directories(${PROJECT_SOURCE_DIR}/src)
+
+set(RESCOMP java -jar ${PROJECT_SOURCE_DIR}/bin/rescomp.jar)
+set(ASMZ80 ${PROJECT_SOURCE_DIR}/bin/sjasm -q)
+set(BINTOS_EXE ${PROJECT_SOURCE_DIR}/bin/bintos)
+
+add_compile_options(
+  -DSGDK_GCC
+  -m68000
+  -Wall
+  -Wextra
+  -Wno-main
+  -Wno-shift-negative-value
+  -Wno-unused-parameter
+  -fno-builtin
+  -nostdlib
+  -nodefaultlibs)
+
+add_compile_options(
+  "$<$<CONFIG:Release,>:-fuse-linker-plugin;-fno-web;-fno-gcse;-fno-unit-at-a-time;-fomit-frame-pointer;-ffat-lto-objects;-flto>"
+  "$<$<CONFIG:Debug>:-O0;-DDEBUG=1>"
+  "$<$<COMPILE_LANGUAGE:ASM>:-xassembler-with-cpp;-Wa,-I${PROJECT_SOURCE_DIR};-Wa,--register-prefix-optional,--bitwise-or>"
+)
+
+# If CMAKE_BUILD_TYPE is not set
+add_compile_options("$<$<CONFIG:>:-O3>")
+
+# Gather sources
+file(GLOB_RECURSE SRC_LIB_C src/*.c)
+string(REPLACE "src/boot/rom_head.c" "" SRC_LIB_C "${SRC_LIB_C}")
+file(GLOB_RECURSE SRC_LIB_S src/*.s)
+string(REPLACE "src/boot/sega.s" "" SRC_LIB_S "${SRC_LIB_S}")
+file(GLOB_RECURSE SRC_LIB_S80 src/*.s80)
+string(REGEX REPLACE "[.]s80" ".s;" Z80SRC ${SRC_LIB_S80})
+file(GLOB_RECURSE RES_LIB_RES res/*.res)
+string(REGEX REPLACE "[.]res" ".s;" RESSRC ${RES_LIB_RES})
+
+# Rules to build Z80 source code
+foreach(z80_source ${Z80SRC})
+  get_filename_component(file ${z80_source} NAME_WE)
+  get_filename_component(dir ${z80_source} DIRECTORY)
+  set(file ${dir}/${file})
+  add_custom_command(
+    OUTPUT ${z80_source}
+    COMMAND ${ASMZ80} -i${PROJECT_SOURCE_DIR}/inc/snd ${file}.s80 ${file}.out &&
+            ${BINTOS_EXE} ${file}.out ${file}.s
+    DEPENDS ${file}.s80 BINTOS SJASM
+    BYPRODUCTS ${file}.out ${file}.h)
+endforeach()
+
+# Rules to build resources
+foreach(res_source ${RESSRC})
+  string(REGEX REPLACE "[.]s" ".h" res_header ${res_source})
+  add_custom_command(
+    OUTPUT ${res_source} ${res_header}
+    COMMAND ${RESCOMP} ${PROJECT_SOURCE_DIR}/res/libres.res
+    DEPENDS ${PROJECT_SOURCE_DIR}/res/libres.res XGMTOOL)
+endforeach()
+
+add_library(md STATIC ${SRC_LIB_C} ${SRC_LIB_S} ${Z80SRC} ${RESSRC})
+set_target_properties(
+  md
+  PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib
+             OUTPUT_NAME "md"
+             DEBUG_OUTPUT_NAME "md_debug")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,10 +100,11 @@ endforeach()
 # Rules to build resources
 foreach(res_source ${RESSRC})
   string(REGEX REPLACE "[.]s" ".h" res_header ${res_source})
+  string(REGEX REPLACE "[.]s" ".res" res ${res_source})
   add_custom_command(
     OUTPUT ${res_source} ${res_header}
-    COMMAND ${RESCOMP} ${PROJECT_SOURCE_DIR}/res/libres.res
-    DEPENDS ${PROJECT_SOURCE_DIR}/res/libres.res XGMTOOL)
+    COMMAND ${RESCOMP} ${res}
+    DEPENDS ${res} XGMTOOL)
 endforeach()
 
 add_library(md STATIC ${SRC_LIB_C} ${SRC_LIB_S} ${Z80SRC} ${RESSRC})


### PR DESCRIPTION
I messed up the previous pullrequest. This is a clean one with only the cmake updated.

To build the libraries, follow the instructions below...

Ensure the PREFIX and GDK env vars are set.

export PREFIX=m68k-elf-
export GDK=~/SGDK

cmake -S $GDK -B $GDK/build_release -DCMAKE_BUILD_TYPE=Release
cmake --build $GDK/build_release
cmake -S $GDK -B $GDK/build_debug -DCMAKE_BUILD_TYPE=Debug
cmake --build $GDK/build_debug

This build file also includes building of the following native utilities.

bintos
xgmtool
sjasm