### PR TITLE
ci: Fix cancelation of Docker builds in CI

### DIFF
--- a/.github/workflows/sgdk-docker.yml
+++ b/.github/workflows/sgdk-docker.yml
@@ -2,7 +2,7 @@ name: sgdk-docker
 
 concurrency:
   group: ${{ github.ref }}-sgdk-docker
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 on:
   workflow_dispatch: # Allows for manual triggering.


### PR DESCRIPTION
The Docker publication workflow tries to optimize and avoid rebuilding GCC if nothing has changed.  However, the very first workflow run that should have created the very first GCC Docker image was canceled.

This changes the concurrency setting on the workflow so that it does not cancel an existing workflow.  This way, if a series of changes are merged rapidly, and an earlier one requires a GCC rebuild, the later workflow runs will see that image.

This allows us to keep the optimization of skipping GCC rebuilds most of the time.