### PR TITLE
[xgmtool] Recognize RF5C68 commands, add a CLI option to keep them

### DIFF
--- a/tools/xgmtool/inc/vgmcom.h
+++ b/tools/xgmtool/inc/vgmcom.h
@@ -23,6 +23,7 @@
 #define VGM_LOOP_START          0x30
 #define VGM_LOOP_END            0x31
 
+#define VGM_WRITE_RF5C68        0xB0
 
 typedef struct
 {
@@ -92,6 +93,7 @@ int VGMCommand_getStreamFrenquency(VGMCommand* source);
 int VGMCommand_getStreamSampleAddress(VGMCommand* source);
 int VGMCommand_getStreamSampleSize(VGMCommand* source);
 bool VGMCommand_isSame(VGMCommand* source, VGMCommand* com);
+bool VGMCommand_isRF5C68Control(VGMCommand* source);
 
 bool VGMCommand_contains(LList* commands, VGMCommand* command);
 VGMCommand* VGMCommand_getKeyOnCommand(LList* commands, int channel);

--- a/tools/xgmtool/inc/xgmtool.h
+++ b/tools/xgmtool/inc/xgmtool.h
@@ -10,6 +10,6 @@ extern bool verbose;
 extern bool sampleIgnore;
 extern bool sampleRateFix;
 extern bool delayKeyOff;
-
+extern bool keepRF5C68Cmds;
 
 #endif // XGMTOOL_H_

--- a/tools/xgmtool/src/vgm.c
+++ b/tools/xgmtool/src/vgm.c
@@ -1136,7 +1136,7 @@ void VGM_cleanCommands(VGM* vgm)
             command = com->element;
 
             // keep data block, stream commands and other misc commands
-            if (VGMCommand_isDataBlock(command) || VGMCommand_isStream(command) || VGMCommand_isLoopStart(command) || VGMCommand_isLoopEnd(command))
+            if (VGMCommand_isDataBlock(command) || VGMCommand_isStream(command) || VGMCommand_isLoopStart(command) || VGMCommand_isLoopEnd(command) || (keepRF5C68Cmds && VGMCommand_isRF5C68Control(command)))
             {
                 optimizedCommands = insertAfterLList(optimizedCommands, command);
                 // loop start ? -->

--- a/tools/xgmtool/src/vgmcom.c
+++ b/tools/xgmtool/src/vgmcom.c
@@ -483,6 +483,11 @@ bool VGMCommand_isSame(VGMCommand* source, VGMCommand* com)
     return !memcmp(&(source->data[source->offset]), &(com->data[com->offset]), source->size);
 }
 
+bool VGMCommand_isRF5C68Control(VGMCommand* source)
+{
+    return source->command == VGM_WRITE_RF5C68;
+}
+
 bool VGMCommand_contains(LList* commands, VGMCommand* command)
 {
     LList* l = commands;

--- a/tools/xgmtool/src/xgmtool.c
+++ b/tools/xgmtool/src/xgmtool.c
@@ -23,7 +23,7 @@ bool verbose;
 bool sampleRateFix;
 bool sampleIgnore;
 bool delayKeyOff;
-
+bool keepRF5C68Cmds;
 
 int main(int argc, char *argv[ ])
 {
@@ -80,6 +80,7 @@ int main(int argc, char *argv[ ])
         printf("-di\tdisable PCM sample auto ignore (it can help when PCM are not properly extracted).\n");
         printf("-dr\tdisable PCM sample rate auto fix (it can help when PCM are not properly extracted).\n");
         printf("-dd\tdisable delayed KEY OFF event when we have KEY ON/OFF in a single frame (it can fix incorrect instrument sound).\n");
+        printf("-r\tkeep RF5C68 register write commands.\n");
 
         exit(1);
     }
@@ -90,6 +91,7 @@ int main(int argc, char *argv[ ])
     sampleIgnore = true;
     sampleRateFix = true;
     delayKeyOff = true;
+    keepRF5C68Cmds = false;
 
     // Open source for binary read (will fail if file does not exist)
     if ((infile = fopen(argv[1], "rb")) == NULL)
@@ -130,6 +132,8 @@ int main(int argc, char *argv[ ])
             sys = SYSTEM_NTSC;
         else if (!strcasecmp(argv[i], "-p"))
             sys = SYSTEM_PAL;
+	else if (!strcasecmp(argv[i], "-r"))
+            keepRF5C68Cmds = true;
         else
             printf("Warning: option %s not recognized (ignored)\n", argv[i]);
     }


### PR DESCRIPTION
As of now, xgmtool will not recognize and thus skip any RF5C68 (the Sega PCM chip) commands it encounters in a VGM file. Fix that :)