### PR TITLE
Fix default makefile target

### DIFF
--- a/makefile.gen
+++ b/makefile.gen
@@ -1,3 +1,6 @@
+all: release
+default: release
+
 MAKEFILE_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 MAKEFILE_DIR := $(subst \,/,$(MAKEFILE_DIR))
 
@@ -107,9 +110,6 @@ $(SRC)/main.c:
 ifneq ("$(wildcard $(GDK)/ext.mk)","")
     include $(GDK)/ext.mk
 endif
-
-all: release
-default: release
 
 Default: release
 Debug: debug


### PR DESCRIPTION
The DEPS support added in 8b07ad7f9d07148e0051221fabc3b0927a6a1370 accidentally broke the default makefile target by including deps above the `all`, `default`, or `release` targets.  Previously, the default (first) target had been `release`.

This moves `all` and `default` to the top, both of which depend on `release`.

Fixes #354