### PR TITLE
Fixed bug with boolean type of object's field in tmx file

### DIFF
--- a/tools/rescomp/src/sgdk/rescomp/type/TMX.java
+++ b/tools/rescomp/src/sgdk/rescomp/type/TMX.java
@@ -825,6 +825,10 @@ public class TMX
                         else
                             addField(objectName, tFields, new TField(name, TiledObjectType.STRING, value));
                     }
+                    // bool type ?
+                    else if (TiledObjectType.fromString(type) == TiledObjectType.BOOL)   
+                        // replace value "true" by "1" or "false" by "0" and add field
+                        addField(objectName, tFields, new TField(name, TiledObjectType.fromString(type), StringUtil.equals(value.toLowerCase(), "true") ? "1":"0"));                          
                     else
                         addField(objectName, tFields, new TField(name, TiledObjectType.fromString(type), value));
                 }


### PR DESCRIPTION
Fixes an bug if the imported .tmx file contains an object with a bool field.
like this:
> (.rodata+0x6)|| undefined reference to `false'