### PR TITLE
Improved the SYS_die function.

### DIFF
--- a/inc/sys.h
+++ b/inc/sys.h
@@ -489,10 +489,11 @@ bool SYS_isChecksumOk(void);
 /**
  *  \brief
  *      Die with the specified error message.<br>
- *      Program execution is interrupted.
- *
+ *      Program execution is interrupted.<br>
+ *      Accepts a list of strings. The list must end with a NULL value.
+ * 
  * This actually display an error message and program ends execution.
  */
-void SYS_die(char *err);
+void SYS_die(char *err, ...);
 
 #endif // _SYS_H_

--- a/src/sys.c
+++ b/src/sys.c
@@ -1042,13 +1042,27 @@ bool SYS_isChecksumOk()
 }
 
 
-void SYS_die(char *err)
+void SYS_die(char *err, ...)
 {
     SYS_setInterruptMaskLevel(7);
     VDP_init();
-    VDP_drawText("A fatal error occured !", 2, 2);
-    VDP_drawText("cannot continue...", 4, 3);
-    if (err) VDP_drawText(err, 0, 5);
+    VDP_setBackgroundColor(63);
+    VDP_drawText("A fatal error occured!", 9, 2);
+    VDP_drawText("cannot continue...", 11, 3);
+    
+    u8 y = 5;
 
+    va_list argptr;
+    va_start(argptr, err);
+
+    const char* str = err;
+    while (str != NULL)
+    {
+        VDP_drawText(str, 1, y);
+        str = va_arg(argptr, const char*);
+        y++;
+    }
+    va_end(argptr);
+    
     while(1);
 }


### PR DESCRIPTION
SYS_die accepts a list of strings. The list must end with a NULL value.
The header is horizontally aligned. The background color has been changed to blue.
Example:
`SYS_die("player_calculateVelocity()", "posBuffer.x is negative", NULL);`

![Screenshot 2024-11-06 at 9 03 22 PM](https://github.com/user-attachments/assets/e2cc6d5a-9992-4dc4-ace7-2af26fe5f156)
