### PR TITLE
Tweaked VDP_showFPS(), VDP_showCPULoad(), BMP_showFPS(), Added VDP_drawTextBGFill()

### DIFF
--- a/inc/bmp.h
+++ b/inc/bmp.h
@@ -405,8 +405,12 @@ void BMP_clearTextLine(u16 y);
  *
  *  \param float_display
  *      If this value is true (!= 0) the frame rate is displayed as float (else it's integer).
+ *  \param x
+ *      X coordinate (in tile).
+ *  \param y
+ *      y coordinate (in tile).
  */
-void BMP_showFPS(u16 float_display);
+void BMP_showFPS(u16 float_display, u16 x, u16 y);
 
 /**
  *  \brief

--- a/inc/vdp.h
+++ b/inc/vdp.h
@@ -1102,22 +1102,31 @@ u16 VDP_getAdjustedVCounter(void);
  *
  *  \param asFloat
  *      Display in float number format.
+ *  \param x
+ *      X coordinate (in tile).
+ *  \param y
+ *      y coordinate (in tile).
  *
  * This function actually display the number of time it was called in the last second.<br>
  * i.e: for benchmarking you should call this method only once per frame update.
  *
  * \see #SYS_getFPS(..)
  */
-void VDP_showFPS(u16 asFloat);
+void VDP_showFPS(u16 asFloat, u16 x, u16 y);
 /**
  *  \brief
  *      Display the estimated CPU load (in %).
+ * 
+*  \param x
+ *      X coordinate (in tile).
+ *  \param y
+ *      y coordinate (in tile).
  *
  * This function actually display an estimation of the CPU load (in %) for the last frame.
  *
  * \see #SYS_getCPULoad()
  */
-void VDP_showCPULoad(void);
+void VDP_showCPULoad(u16 x, u16 y);
 
 
 #endif // _VDP_H_

--- a/inc/vdp_bg.h
+++ b/inc/vdp_bg.h
@@ -505,6 +505,36 @@ void VDP_drawText(const char* str, u16 x, u16 y);
 
 /**
  *  \brief
+ *      Draw text in specified plane and clear remaining unused space.<br>
+ *      If the new line is shorter than the one previously drawn in this place, the old characters will be removed.<br>
+ *      This function works significantly faster than calling VDP_clearText() and then VDP_drawText().
+ *      It is suitable when a lot of updating information needs to be displayed on the screen.
+ *
+ *  \param plane
+ *      Plane where we want to draw text.<br>
+ *      Accepted values are:<br>
+ *      - BG_A<br>
+ *      - BG_B<br>
+ *      - WINDOW<br>
+ *  \param str
+ *      String to draw. For correct operation, it must not exceed 40 characters.
+ *  \param x
+ *      X position (in tile).
+ *  \param y
+ *      y position (in tile).
+ *  \param len
+ *      Fixed string length. For correct operation, it must not exceed 40 characters.
+ *
+ *  \see VDP_drawText(..)
+ *  \see VDP_clearText(..)
+ *  \see VDP_setTextPalette(..)
+ *  \see VDP_setTextPriority(..)
+ *  \see VDP_setTextPlane(..)
+ */
+void VDP_drawTextBGFill(VDPPlane plane, const char* str, u16 x, u16 y, u16 len);
+
+/**
+ *  \brief
  *      Draw text and clear remaining unused space.<br>
  *      If the new line is shorter than the one previously drawn in this place, the old characters will be removed.<br>
  *      This function works significantly faster than calling VDP_clearText() and then VDP_drawText().

--- a/sample/benchmark/src/bmp_test.c
+++ b/sample/benchmark/src/bmp_test.c
@@ -661,7 +661,7 @@ u16 executeBMPTest(u16 *scores)
             end = getTimeAsFix32(FALSE);
             time += end - start;
             j += j >> 5;
-            BMP_showFPS(FALSE);
+            BMP_showFPS(FALSE, 1, 1);
             BMP_flip(FALSE);
         }
         for(j = 127; j >= 32; j--)
@@ -671,7 +671,7 @@ u16 executeBMPTest(u16 *scores)
             end = getTimeAsFix32(FALSE);
             time += end - start;
             j -= j >> 5;
-            BMP_showFPS(FALSE);
+            BMP_showFPS(FALSE, 1, 1);
             BMP_flip(FALSE);
         }
     }

--- a/sample/benchmark/src/spr_test.c
+++ b/sample/benchmark/src/spr_test.c
@@ -1028,8 +1028,8 @@ static u16 executePartic(u16 time, u16 numPartic, u16 preloadedTiles, u16 reallo
         // update sprites
         SPR_update();
 
-        VDP_showFPS(FALSE);
-        VDP_showCPULoad();
+        VDP_showFPS(FALSE, 1, 1);
+        VDP_showCPULoad(1, 2);
         SYS_doVBlankProcess();
         cpuLoad = SYS_getCPULoad();
 
@@ -1181,8 +1181,8 @@ static u16 executeDonut(u16 time, u16 preloadedTiles)
         // update sprites
         SPR_update();
 
-        VDP_showFPS(FALSE);
-        VDP_showCPULoad();
+        VDP_showFPS(FALSE, 1, 1);
+        VDP_showCPULoad(1, 2);
 
         SYS_doVBlankProcess();
         cpuLoad = SYS_getCPULoad();
@@ -1310,8 +1310,8 @@ static u16 execute(u16 time, u16 numSpr)
         // update sprites
         SPR_update();
 
-        VDP_showFPS(FALSE);
-        VDP_showCPULoad();
+        VDP_showFPS(FALSE, 1, 1);
+        VDP_showCPULoad(1, 2);
         SYS_doVBlankProcess();
         cpuLoad = SYS_getCPULoad();
 

--- a/sample/bitmap/cube 3D/src/main.c
+++ b/sample/bitmap/cube 3D/src/main.c
@@ -93,7 +93,7 @@ int main()
 
         // ensure previous flip buffer request has been started
 //        BMP_waitWhileFlipRequestPending();
-        BMP_showFPS(1);
+        BMP_showFPS(TRUE, 1, 1);
 
         BMP_clear();
 

--- a/sample/bitmap/partic/src/main.c
+++ b/sample/bitmap/partic/src/main.c
@@ -73,7 +73,7 @@ int main(bool hard)
             BMP_waitWhileFlipRequestPending();
 
             // can now draw text
-            BMP_showFPS(0);
+            BMP_showFPS(FALSE, 1, 1);
 
             // display particul number
             intToStr(numpartic, str, 1);

--- a/sample/demo/starfield-donut/src/main.c
+++ b/sample/demo/starfield-donut/src/main.c
@@ -131,7 +131,7 @@ static void fastStarFieldFX()
         SPR_update();
 
 //        SYS_disableInts();
-//        VDP_showFPS(FALSE);
+//        VDP_showFPS(FALSE, 1, 1);
 //        SYS_enableInts();
 
         //VDP_waitVSync();

--- a/sample/snd/xgm-player/src/main.c
+++ b/sample/snd/xgm-player/src/main.c
@@ -404,7 +404,7 @@ int main()
         if (bgEnabled) updateBGScroll();
 
 //        SYS_disableInts();
-//        VDP_showFPS(FALSE);
+//        VDP_showFPS(FALSE, 1, 1);
 //        SYS_enableInts();
 
 //        VDP_setBackgroundColor(3);

--- a/src/bmp.c
+++ b/src/bmp.c
@@ -306,24 +306,23 @@ void BMP_clearTextLine(u16 y)
 }
 
 
-void BMP_showFPS(u16 float_display)
+void BMP_showFPS(u16 float_display, u16 x, u16 y)
 {
     char str[16];
-    const u16 y = GET_YOFFSET + 1;
+    y = GET_YOFFSET + y;
 
     if (float_display)
     {
         fix32ToStr(SYS_getFPSAsFloat(), str, 1);
-        VDP_clearTextBG(bmp_plan, 2, y, 5);
+        // display FPS
+        VDP_drawTextBGFill(bmp_plan, str, x, y, 4);
     }
     else
     {
         uintToStr(SYS_getFPS(), str, 1);
-        VDP_clearTextBG(bmp_plan, 2, y, 2);
+        // display FPS
+        VDP_drawTextBGFill(bmp_plan, str, x, y, 2);
     }
-
-    // display FPS
-    VDP_drawTextBG(bmp_plan, str, 1, y);
 }
 
 

--- a/src/vdp.c
+++ b/src/vdp.c
@@ -993,35 +993,33 @@ u16 VDP_getAdjustedVCounter()
 }
 
 
-void VDP_showFPS(u16 asFloat)
+void VDP_showFPS(u16 asFloat, u16 x, u16 y)
 {
     char str[16];
 
     if (asFloat)
     {
         fix32ToStr(SYS_getFPSAsFloat(), str, 1);
-        VDP_clearText(2, 1, 5);
+        // display FPS
+        VDP_drawTextFill(str, x, y, 4);
     }
     else
     {
         uintToStr(SYS_getFPS(), str, 1);
-        VDP_clearText(2, 1, 2);
+        // display FPS
+        VDP_drawTextFill(str, x, y, 2);
     }
-
-    // display FPS
-    VDP_drawText(str, 1, 1);
 }
 
-void VDP_showCPULoad()
+void VDP_showCPULoad(u16 x, u16 y)
 {
     char str[16];
 
     uintToStr(SYS_getCPULoad(), str, 1);
     strcat(str, "%");
 
-    VDP_clearText(2, 2, 4);
-    // display FPS
-    VDP_drawText(str, 1, 2);
+    // display CPU load
+    VDP_drawTextFill(str, x, y, 4);
 }
 
 

--- a/src/vdp_bg.c
+++ b/src/vdp_bg.c
@@ -382,7 +382,7 @@ void VDP_drawText(const char* str, u16 x, u16 y)
     VDP_drawTextBG(text_plan, str, x, y);
 }
 
-void VDP_drawTextFill(const char* str, u16 x, u16 y, u16 len)
+void VDP_drawTextBGFill(VDPPlane plane, const char* str, u16 x, u16 y, u16 len)
 {
     char fixedStr[len + 1];
     char* dst = fixedStr;
@@ -405,7 +405,12 @@ void VDP_drawTextFill(const char* str, u16 x, u16 y, u16 len)
     // set back terminator char
     *dst = '\0';
 
-    VDP_drawText(fixedStr, x, y);
+    VDP_drawTextBG(plane, fixedStr, x, y);
+}
+
+void VDP_drawTextFill(const char* str, u16 x, u16 y, u16 len)
+{
+    VDP_drawTextBGFill(text_plan, str, x, y, len);
 }
 
 void VDP_clearText(u16 x, u16 y, u16 w)


### PR DESCRIPTION
I added coordinates to arguments in showFPS and CPULoad because it can be useful in some cases (e.g. when text is on the window plane)
Also I replaced drawText to drawTextFill for better performance