### PR TITLE
Install ConvSym in SGDK's Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,11 @@ RUN find . -name "*.java" | xargs javac
 RUN echo -e "Main-Class: sgdk.xgm2tool.Launcher\nClass-Path: apj.jar lz4w.jar" > Manifest.txt
 RUN jar cfm $SGDK_PATH/bin/xgm2tool.jar Manifest.txt  .
 
+# Building convsym
+WORKDIR $SGDK_PATH/tools/convsym
+RUN make
+RUN cp build/convsym $SGDK_PATH/bin/convsym
+
 # Copy m68k compiler from base image
 COPY --from=m68k-files /m68k/ /usr/
 ENV PATH="$SGDK_PATH/bin:${PATH}"


### PR DESCRIPTION
Users using SGDK with Docker reported that "debug" build profile has issues. This is likely because Docker image doesn't build `convsym`.

I verified that `consym` is available from docker container now.

## How to test

This is what I used to quickly verify this:

```sh
cd SGDK/
docker build -t sgdk .
docker run --rm --entrypoint convsym sgdk
```