### PR TITLE
Added new resource file option to sort objects by a user specified field.

### DIFF
--- a/tools/rescomp/src/sgdk/rescomp/processor/ObjectsProcessor.java
+++ b/tools/rescomp/src/sgdk/rescomp/processor/ObjectsProcessor.java
@@ -64,7 +64,7 @@ public class ObjectsProcessor implements Processor
         if (fields.length < 5)
         {
             System.out.println("Wrong OBJECTS definition");
-            System.out.println("OBJECTS name tmx_file layer_id field_defs [decl_type [type_filter]]");
+            System.out.println("OBJECTS name tmx_file layer_id field_defs [sortby:<field>] [decl_type [type_filter]]");
             System.out.println("name            name of the output array Objects structure");
             System.out.println("tmx_file        path of the input TMX file (TMX Tiled file)");
             System.out.println("layer_id        object group/layer name we want to extract object from.");
@@ -74,6 +74,7 @@ public class ObjectsProcessor implements Processor
             System.out.println("                        \"type:u16;name:string;x:f32;y:f32;tileindex:u32\"");
             System.out.println("                        \"type:u16;power:s8;visible:bool\"");
             System.out.println("                    Not found fields are just ignored so you can extract different object types easily.");
+            System.out.println("sortby          optional, field name to sort objects by. e.g. \"sortby:x\" to sort objects by x position.");
             System.out.println("decl_type       declaration type for objects (default is \"void\").");
             System.out.println("                    By default object array is untyped (void) but you can specify your own type if you want (\"Object\", \"Entity\", ...)");
             System.out.println("type_filter     define a type filter if we only want to extract Tiled objects of a specific type.");
@@ -89,20 +90,31 @@ public class ObjectsProcessor implements Processor
         final String layerName = fields[3];
         // get fields definition value
         final String fieldDefs = fields[4];
-        String declType = "";
-        if (fields.length >= 6)
-            declType = fields[5];
-        String typeFilter = "";
-        if (fields.length >= 7)
-            typeFilter = fields[6];
 
+        int index = 5;
+        String sortBy = "";
+
+        if (index < fields.length && fields[index].startsWith("sortby:"))
+        {
+            sortBy = fields[index++].substring(7);
+        }
+
+        // Index could be 5 or 6 depending on if sortby is present
+        String declType = "";
+        String typeFilter = "";
+        if (index < fields.length)
+        {
+            declType = fields[index++];
+            if (index < fields.length)
+                typeFilter = fields[index++];
+        }
         final LinkedHashMap<String, SGDKObjectType> fieldDefsMap = buildFieldDefsMap(fieldDefs);
 
         // add resource file (used for deps generation)
         Compiler.addResourceFile(fileIn);
 
         // build TMX objects
-        final TMXObjects tmxObjects = new TMXObjects(id, fileIn, layerName, fieldDefsMap, typeFilter);
+        final TMXObjects tmxObjects = new TMXObjects(id, fileIn, layerName, sortBy, fieldDefsMap, typeFilter);
         // build OBJECTS from TMX objects
         return new Objects(id, declType, tmxObjects.objects);
     }

--- a/tools/rescomp/src/sgdk/rescomp/type/TMX.java
+++ b/tools/rescomp/src/sgdk/rescomp/type/TMX.java
@@ -696,7 +696,7 @@ public class TMX
         public final String layerName;
         public final List<SObject> objects;
 
-        public TMXObjects(String baseId, String file, String layerName, LinkedHashMap<String, SGDKObjectType> fieldDefs, String typeFilter) throws Exception
+        public TMXObjects(String baseId, String file, String layerName, String sortBy, LinkedHashMap<String, SGDKObjectType> fieldDefs, String typeFilter) throws Exception
         {
             if (!FileUtil.exists(file))
                 throw new FileNotFoundException("TMX file '" + file + " not found !");
@@ -865,7 +865,7 @@ public class TMX
             }
 
             // sort objects on tile index (if it exists)
-            Collections.sort(objects, new ObjectComparator());
+            Collections.sort(objects, new ObjectComparator(sortBy));
         }
 
         private static boolean addField(String objectName, Map<String, TField> fields, TField field)
@@ -911,23 +911,37 @@ public class TMX
 
         static class ObjectComparator implements Comparator<SObject>
         {
+            String sortBy;
+
+            ObjectComparator(String sortBy)
+            {
+                this.sortBy = sortBy;
+            }
+
             @Override
             public int compare(SObject o1, SObject o2)
             {
                 int result;
 
-                // sort first on 'index' field
-                result = Long.compare(o1.getFieldLongValue(FIELD_INDEX), o2.getFieldLongValue(FIELD_INDEX));
-                // then sort on 'ind' field
-                if (result == 0)
-                    result = Long.compare(o1.getFieldLongValue(FIELD_IND), o2.getFieldLongValue(FIELD_IND));
-                // then sort on 'tileindex' field
-                if (result == 0)
-                    result = Long.compare(o1.getFieldLongValue(FIELD_TILE_INDEX), o2.getFieldLongValue(FIELD_TILE_INDEX));
-                // then sort on 'id' field
-                if (result == 0)
-                    result = Long.compare(o1.getFieldLongValue(FIELD_ID), o2.getFieldLongValue(FIELD_ID));
-
+                if (StringUtil.isEmpty(sortBy))
+                {
+                    // sort first on 'index' field
+                    result = Long.compare(o1.getFieldLongValue(FIELD_INDEX), o2.getFieldLongValue(FIELD_INDEX));
+                    // then sort on 'ind' field
+                    if (result == 0)
+                        result = Long.compare(o1.getFieldLongValue(FIELD_IND), o2.getFieldLongValue(FIELD_IND));
+                    // then sort on 'tileindex' field
+                    if (result == 0)
+                        result = Long.compare(o1.getFieldLongValue(FIELD_TILE_INDEX), o2.getFieldLongValue(FIELD_TILE_INDEX));
+                    // then sort on 'id' field
+                    if (result == 0)
+                        result = Long.compare(o1.getFieldLongValue(FIELD_ID), o2.getFieldLongValue(FIELD_ID));
+                }
+                else
+                {
+                    // sort by user specified field
+                    result = Long.compare(o1.getFieldLongValue(sortBy), o2.getFieldLongValue(sortBy));
+                }
                 return result;
             }
         }


### PR DESCRIPTION
A backward compatible enhancement to allow the user to specify a field to use when sorting objects from TMX files.
The new parameter "s**ortby:_field_**" where _field_ is the name of the field/attribute of the object to be used for sorting.

A good example of where this might be used to to sort objects by their exported x position.

@Stephane-D , please let me know if you have any feedback.

Thanks.
