### PR TITLE
Include genesis.h in resource header. To suppress warnings.

### DIFF
--- a/tools/rescomp/src/sgdk/rescomp/Compiler.java
+++ b/tools/rescomp/src/sgdk/rescomp/Compiler.java
@@ -208,7 +208,8 @@ public class Compiler
             headerName = headerName.toUpperCase();
 
             outH.append("#ifndef _" + headerName + "_H_\n");
-            outH.append("#define _" + headerName + "_H_\n\n");
+            outH.append("#define _" + headerName + "_H_\n");
+            outH.append("#include <genesis.h>\n\n");
 
             // -- BINARY SECTION --
 

--- a/tools/rescomp/src/sgdk/rescomp/Compiler.java
+++ b/tools/rescomp/src/sgdk/rescomp/Compiler.java
@@ -207,9 +207,9 @@ public class Compiler
             headerName += "_" + FileUtil.getFileName(fileNameOut, false);
             headerName = headerName.toUpperCase();
 
+            outH.append("#include <genesis.h>\n");            
             outH.append("#ifndef _" + headerName + "_H_\n");
-            outH.append("#define _" + headerName + "_H_\n");
-            outH.append("#include <genesis.h>\n\n");
+            outH.append("#define _" + headerName + "_H_\n\n");
 
             // -- BINARY SECTION --
 


### PR DESCRIPTION
Hey there! I'm happy to introduce myself. 
I recently started using SDGK, and I'm absolutely loving it!
I added an include because the resource header gives a warning (Unknown type name). 
It's not a code that is always necessary, but and I'd be happy if you could pull it.