### PR TITLE
Updated doxygen, corrected Xeno Crisis promotional .gif

### DIFF
--- a/.github/workflows/publish-doxygen.yml
+++ b/.github/workflows/publish-doxygen.yml
@@ -10,8 +10,8 @@ on:
 env:
   # Used to find the download link:
   # https://www.doxygen.nl/files/doxygen-X.XX.X.linux.bin.tar.gz
-  # Version # updated on: 2025.02.28
-  DOXYGEN_VERSION: 1.13.2
+  # Version # updated on: 2025.06.13
+  DOXYGEN_VERSION: 1.14.0
 
 jobs:
   cleanup:


### PR DESCRIPTION
These changes include:
- Updated Doxygen from 1.13.2 to 1.14.0
- Removed two frames of screen shake game_xenocrisis.gif

With the screen shake frames removed it makes the gif loop much smoother.