### PR TITLE
fixed: offsetXFlip instead offsetX for vertically flipped sprite in …

### DIFF
--- a/src/sprite_eng.c
+++ b/src/sprite_eng.c
@@ -1981,7 +1981,7 @@ static u16 updateVisibility(Sprite* sprite, u16 status)
                                 visibility |= 1;
 
 #ifdef SPR_DEBUG
-                            KLog_S4("    offx+bx=", (u16)(frameSprite->offsetXFlip + bx), " offy+by=", (u16)(frameSprite->offsetYFlip + by), " mx=", mx, " my=", my);
+                            KLog_S4("    offx+bx=", (u16)(frameSprite->offsetX + bx), " offy+by=", (u16)(frameSprite->offsetYFlip + by), " mx=", mx, " my=", my);
 #endif
 
                             // next


### PR DESCRIPTION
…debuglog (SPR_DEBUG) of sprite_eng.c.