### PR TITLE
Added VDP_loadTileSetEx to load a subset of tiles from a tileset

### DIFF
--- a/inc/vdp_tile.h
+++ b/inc/vdp_tile.h
@@ -209,6 +209,37 @@ void VDP_loadTileData(const u32 *data, u16 index, u16 num, TransferMethod tm);
 bool VDP_loadTileSet(const TileSet *tileset, u16 index, TransferMethod tm);
 /**
  *  \brief
+ *      Load a subset of tile data (pattern) in VRAM. Useful to only reload a part of a tileSet if it;s been overwritten
+ *      or in case of streaming maps, to get the required tiles out of the full tile atlas
+ *
+ *  \param tileset
+ *      Pointer to TileSet structure.<br>
+ *      The TileSet is unpacked "on-the-fly" if needed (require some memory).<br>
+ *      Using DMA_QUEUE for packed resource is unsafe as the resource will be released and eventually
+ *      can be overwritten before DMA operation so use DMA_QUEUE_COPY in that case or unpack the resource first.
+ *  \param index
+ *      Tile index where start tile data load (use TILE_USER_INDEX as base user index).
+ *  \param fromTile
+ *      Start tile index to be loaded from the set.
+ *  \param count
+ *      Number of tiles to Load.
+ *  \param tm
+ *      Transfer method.<br>
+ *      Accepted values are:<br>
+ *      - CPU<br>
+ *      - DMA<br>
+ *      - DMA_QUEUE<br>
+ *      - DMA_QUEUE_COPY
+ *  \return
+ *      FALSE if there is not enough memory to unpack the specified TileSet (only if compression was enabled).
+ *
+ *  Transfert rate:<br>
+ *  ~90 bytes per scanline in software (during blanking)<br>
+ *  ~190 bytes per scanline in hardware (during blanking)
+ */
+bool VDP_loadTileSetEx(const TileSet *tileSet, u16 index, u16 fromTile, u16 count, TransferMethod tm);
+/**
+ *  \brief
  *      Load font tile data in VRAM.<br>
  *      Note that you should prefer the VDP_loadFont(..) method to this one (easier to use).
  *

--- a/src/vdp_tile.c
+++ b/src/vdp_tile.c
@@ -58,6 +58,29 @@ bool VDP_loadTileSet(const TileSet *tileset, u16 index, TransferMethod tm)
     return TRUE;
 }
 
+bool VDP_loadTileSetEx(const TileSet *tileSet, u16 index, u16 fromTile, u16 count, TransferMethod tm)
+{
+    // compressed tileset ?
+    if (tileset->compression != COMPRESSION_NONE)
+    {
+        // unpack first
+        TileSet *t = unpackTileSet(tileset, NULL);
+
+        if (t == NULL) return FALSE;
+
+        // tiles
+        VDP_loadTileData(t->tiles+(fromTile << 3), index, count, tm);
+        // be careful, we are releasing buffer here so DMA_QUEUE transfer isn't safe here, use DMA_QUEUE_COPY instead for safe operation
+        MEM_free(t);
+    }
+    else
+        // tiles
+        VDP_loadTileData(FAR_SAFE((tileSet->tiles)+(fromTile << 3), count << 5), index, count, tm);
+
+    return TRUE;
+}
+
+
 bool VDP_loadFont(const TileSet *font, TransferMethod tm)
 {
     return VDP_loadTileSet(font, TILE_FONT_INDEX, tm);

--- a/src/vdp_tile.c
+++ b/src/vdp_tile.c
@@ -38,24 +38,7 @@ void VDP_loadFontData(const u32 *font, u16 length, TransferMethod tm)
 
 bool VDP_loadTileSet(const TileSet *tileset, u16 index, TransferMethod tm)
 {
-    // compressed tileset ?
-    if (tileset->compression != COMPRESSION_NONE)
-    {
-        // unpack first
-        TileSet *t = unpackTileSet(tileset, NULL);
-
-        if (t == NULL) return FALSE;
-
-        // tiles
-        VDP_loadTileData(t->tiles, index, t->numTile, tm);
-        // be careful, we are releasing buffer here so DMA_QUEUE transfer isn't safe here, use DMA_QUEUE_COPY instead for safe operation
-        MEM_free(t);
-    }
-    else
-        // tiles
-        VDP_loadTileData(FAR_SAFE(tileset->tiles, tileset->numTile * 32), index, tileset->numTile, tm);
-
-    return TRUE;
+    return VDP_loadTileSetEx(tileSet, index, 0, tileset->numTile, tm);
 }
 
 bool VDP_loadTileSetEx(const TileSet *tileSet, u16 index, u16 fromTile, u16 count, TransferMethod tm)


### PR DESCRIPTION
Stef, we talked about this in the past but there was no clear use-case to explain the usefulness. But now after 4 projects, this is  the helper function i found myself adding every time, and the last project gave me the best use case for this:

Implementing a map with streaming tiles while scrolling, as you don't know which tiles you need at each incoming column in advance, this lets you pack all the tiles in one atlas and just extract the one you need. Bonus perf if you can pre-arrange strips of tiles in columns for example. (I'll probably write a sample when I have time)

But the two other case I was using this is, allowing you to temporary overwrite a par t of a loaded tileset when it's not needed and only reload the overwritten tiles, without having to create multiple split tileset.

It's also quite useful in the planning stage when you still don't have the final vram layout, as you can create a giant tileset covering the whole vram area to manually place tiles at fixed index and test everything only loading the parts you need when you need them.

I hope it gets added and specially that you can review my implementation, which my not be the best. (In my helper i don't have the compressed part as, generally, this dynamic subset loading is at runtime so better to be used on uncompressed tilesets, up to you if to keep it or strip it and add a note)

