### PR TITLE
Removed broken links from list of SGDK-powered games and demos

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -210,9 +210,7 @@ Demons of Asteborg [Neofid Studios](https://neofid-studios.com/)
 * [Return to Genesis](https://www.youtube.com/watch?v=jjy0Iz_64dY) unofficial MD port by Z-Team
 * [Road to Valhalla](https://www.pouet.net/prod.php?which=72961) by Bounty/Banana & Resistance
 * [Spiral (the)](https://www.pouet.net/prod.php?which=82607) by Resistance
-* [TCK](https://www.cursed-knight.fr/cursed-knight-fr.php) by GGS Studio Creation
 * [Tetris MD](https://github.com/NeroJin/TetrisMD) unofficial MD port by Nero Jin
-* [ThunderCats MD](https://github.com/mxfolken/thundercats_megadrive) by Rolando Fernández Benavidez.
 * [Travel](https://www.pouet.net/prod.php?which=65975) by Resistance
 * [Wacky Willy Weiner Sausage Surfer](https://globalgamejam.org/2017/games/wacky-willy-weiner-sausage-surfer) made for the GGJ 2017
 


### PR DESCRIPTION
removed links:
* [TCK](https://www.cursed-knight.fr/cursed-knight-fr.php) by GGS Studio Creation
* [ThunderCats MD](https://github.com/mxfolken/thundercats_megadrive) by Rolando Fernández Benavidez.