### PR TITLE
refactoring: remove two unused variables

### DIFF
--- a/tools/xgmtool/src/xgc.c
+++ b/tools/xgmtool/src/xgc.c
@@ -113,10 +113,8 @@ static void XGC_extractMusic(XGM* xgc, XGM* xgm)
     YM2612* ymOldState;
     YM2612* ymState;
     int j, size;
-    int time;
     bool hasKeyCom;
 
-    time = 0;
     ymLoopState = NULL;
     ymOldState = NULL;
     ymState = YM2612_create();

--- a/tools/xgmtool/src/xgmcom.c
+++ b/tools/xgmtool/src/xgmcom.c
@@ -410,12 +410,9 @@ static XGMCommand* XGMCommand_createPCMCommand(XGM* xgm, VGM* vgm, VGMCommand* c
     if (VGMCommand_isStreamStartLong(command))
     {
         int address;
-        int size;
         Sample* vgmSample;
 
         address = VGMCommand_getStreamSampleAddress(command);
-        size = VGMCommand_getStreamSampleSize(command);
-//        vgmSample = VGM_getSample(vgm, address, size);
         vgmSample = VGM_getSample(vgm, address);
 
         // use stream id as priority


### PR DESCRIPTION
These variables are obviously not used.
Gcc showed warnings (`[-Wunused-but-set-variable]`) during compilation of `xgmtool`.

Gcc showed others `[-Wunused-but-set-variable]` but they were less obvious and I don't know how to test properly `xgmtool`, so I did not modify them.